### PR TITLE
fix: Add `runInShell` when running on Windows

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase.dart
+++ b/packages/flutterfire_cli/lib/src/firebase.dart
@@ -34,6 +34,7 @@ Future<bool> exists() async {
   final process = await Process.run(
     'firebase',
     ['--version'],
+    runInShell: Platform.isWindows,
   );
   return _existsCache = process.exitCode == 0;
 }
@@ -86,6 +87,7 @@ Future<Map<String, dynamic>> runFirebaseCommand(
     'firebase',
     execArgs,
     workingDirectory: workingDirectoryPath,
+    runInShell: Platform.isWindows,
   );
 
   final jsonString = process.stdout.toString();


### PR DESCRIPTION
Without it, it would throw the error: `ProcessException: The system cannot find the file specified.`
I used `Platform.isWindows` instead of `true` as I am not sure of the implications of this on other systems.

Supposedly fixes #3