### PR TITLE
ci: bump conventional PR title checker version

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v4.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -1,4 +1,4 @@
-name: 'PR Title is Conventional'
+name: "PR Title is Conventional"
 on:
   pull_request_target:
     types:
@@ -10,6 +10,6 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v2.1.0
+      - uses: amannn/action-semantic-pull-request@v4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Details

Upgrade version of the [`action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) GitHub Action, which validates that PR titles match the [Conventional Commits spec](https://www.conventionalcommits.org/).

## Context

At the moment (`flutterfire_cli v0.1.1+2`), any PR includes i̶s̶ r̶e̶j̶e̶c̶t̶e̶d̶ a̶n̶d̶ m̶a̶r̶k̶e̶d̶ a̶s̶ *̶*̶F̶a̶i̶l̶i̶n̶g̶*̶*̶ d̶u̶e̶ t̶o̶  a deprecation notice thrown by the `2.1.0` version of the action.
More info [here](https://github.com/amannn/action-semantic-pull-request/issues/62).