### PR TITLE
fix: `GoogleService-Info.plist` file not found by Firebase SDK unless added to target

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -508,10 +508,14 @@ class ConfigCommand extends FlutterFireCommand {
           generateRubyScript(googleServiceInfoFile, xcodeProjFilePath);
 
       if (Platform.isMacOS) {
-        await Process.run('ruby', [
+        final result = await Process.run('ruby', [
           '-e',
           rubyScript,
         ]);
+
+        if (result.exitCode != 0) {
+          throw Exception(result.stderr);
+        }
       }
     }
 
@@ -534,10 +538,14 @@ class ConfigCommand extends FlutterFireCommand {
           generateRubyScript(googleServiceInfoFile, xcodeProjFilePath);
 
       if (Platform.isMacOS) {
-        await Process.run('ruby', [
+        final result = await Process.run('ruby', [
           '-e',
           rubyScript,
         ]);
+
+        if (result.exitCode != 0) {
+          throw Exception(result.stderr);
+        }
       }
     }
 

--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -236,8 +236,13 @@ end
 if googleConfigExists == false
   file = project.new_file(googleFile)
   main_target = project.targets.find { |target| target.name == 'Runner' }
-  main_target.add_file_references([file])
-  project.save
+  
+  if(main_target)
+    main_target.add_file_references([file])
+    project.save
+  else
+    abort("Could not find target 'Runner' in your Xcode workspace. Please rename your target to 'Runner' and try again.")
+  end  
 end
 ''';
 }

--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -234,7 +234,9 @@ end
 
 # Write only if config doesn't exist
 if googleConfigExists == false
-  project.new_file(googleFile)
+  file = project.new_file(googleFile)
+  main_target = project.targets.find { |target| target.name == 'Runner' }
+  main_target.add_file_references([file])
   project.save
 end
 ''';


### PR DESCRIPTION
## Description

I noticed whilst debugging this [issue](https://github.com/firebase/flutterfire/issues/9400) that initialization was occurring from the dart config file, not the `GoogleService-Info.plist` file. It appears Firebase will not pick up the file unless it is added to the target.

I also think we should stop writing the config to the `DefaultFirebaseOptions` class for android & iOS. Unnecessary and, I think, confusing to users.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
