### PR TITLE
fix: reuse projectId when displayName is null on configure

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_project.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_project.dart
@@ -54,7 +54,8 @@ class FirebaseProject {
       : this(
           projectId: json['projectId'] as String,
           projectNumber: json['projectNumber'] as String,
-          displayName: json['displayName'] as String,
+          displayName:
+              json['displayName'] as String? ?? json['projectId'] as String,
           name: json['name'] as String,
           state: json['state'] as String,
           resources: FirebaseProjectResources.fromJson(
@@ -64,7 +65,7 @@ class FirebaseProject {
 
   final String projectId;
 
-  final String displayName;
+  final String? displayName;
 
   final String name;
 


### PR DESCRIPTION
## Description

This fixes #86 by reusing the projectId as the displayName when a displayName is null. This is because displayName is an optional field for projects. See the following link for more information: https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project.FIELDS.name

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
