### PR TITLE
feat: add option to install firebase additional packages, add precomp…

### DIFF
--- a/packages/flutterfire_starter/__brick__/ios/Podfile
+++ b/packages/flutterfire_starter/__brick__/ios/Podfile
@@ -30,9 +30,25 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 {{#uses_firestore}}
+require 'yaml'
+
+pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
+library_version = pubspec['version'].gsub('+', '-')
+
+if defined?($FirebaseSDKVersion)
+  Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+  firebase_sdk_version = $FirebaseSDKVersion
+else
+  firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))), 'firebase_core/ios/firebase_sdk_version.rb')
+  if File.exist?(firebase_core_script)
+    require firebase_core_script
+    firebase_sdk_version = firebase_sdk_version!
+    Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core'"
+  end
+end
   # Currently, the Firestore iOS SDK depends on some 500k lines of mostly C++ code which can take upwards of 5 minutes to build in Xcode. 
   # To reduce build times significantly, you can use this pre-compiled version by keeping this line in.
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '9.6.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '#{firebase_sdk_version}'
 {{/uses_firestore}}
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/packages/flutterfire_starter/__brick__/ios/Podfile
+++ b/packages/flutterfire_starter/__brick__/ios/Podfile
@@ -48,7 +48,7 @@ else
 end
   # Currently, the Firestore iOS SDK depends on some 500k lines of mostly C++ code which can take upwards of 5 minutes to build in Xcode. 
   # To reduce build times significantly, you can use this pre-compiled version by keeping this line in.
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '#{firebase_sdk_version}'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => 'main'
 {{/uses_firestore}}
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/packages/flutterfire_starter/__brick__/ios/Podfile
+++ b/packages/flutterfire_starter/__brick__/ios/Podfile
@@ -1,0 +1,44 @@
+platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+{{#uses_firestore}}
+  # Currently, the Firestore iOS SDK depends on some 500k lines of mostly C++ code which can take upwards of 5 minutes to build in Xcode. 
+  # To reduce build times significantly, you can use this pre-compiled version by keeping this line in.
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '9.6.0'
+{{/uses_firestore}}
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/packages/flutterfire_starter/__brick__/ios/Podfile
+++ b/packages/flutterfire_starter/__brick__/ios/Podfile
@@ -30,22 +30,6 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 {{#uses_firestore}}
-require 'yaml'
-
-pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
-library_version = pubspec['version'].gsub('+', '-')
-
-if defined?($FirebaseSDKVersion)
-  Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-else
-  firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))), 'firebase_core/ios/firebase_sdk_version.rb')
-  if File.exist?(firebase_core_script)
-    require firebase_core_script
-    firebase_sdk_version = firebase_sdk_version!
-    Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core'"
-  end
-end
   # Currently, the Firestore iOS SDK depends on some 500k lines of mostly C++ code which can take upwards of 5 minutes to build in Xcode. 
   # To reduce build times significantly, you can use this pre-compiled version by keeping this line in.
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => 'main'

--- a/packages/flutterfire_starter/brick.yaml
+++ b/packages/flutterfire_starter/brick.yaml
@@ -24,3 +24,27 @@ vars:
     description: Organization name
     default: com.example
     prompt: What is your organization name?
+
+  firebase_packages:
+    type: array
+    description: additional packages
+    defaults: []
+    prompt: Which additional packages you want to add?
+    values:
+      - cloud_firestore
+      - firebase_database
+      - firebase_auth
+      - firebase_messaging
+      - firebase_in_app_messaging
+      - firebase_analytics
+      - firebase_crashlytics
+      - firebase_storage
+      - firebase_dynamic_links
+      - firebase_remote_config
+      - firebase_performance
+      - cloud_functions
+      - firebase_app_check
+      - firebase_app_installations
+      - firebase_ml_model_downloader
+      - firebase_ml_custom
+      - cloud_firestore_odm

--- a/packages/flutterfire_starter/hooks/pre_gen.dart
+++ b/packages/flutterfire_starter/hooks/pre_gen.dart
@@ -4,7 +4,13 @@ import 'package:mason/mason.dart';
 
 Future<void> run(HookContext context) async {
   final appGenerated = context.logger.progress('Generating a Flutter App');
+  final firebaseAdditionalPackages =
+      context.vars['firebase_packages'] as List;
   try {
+    context.vars = <String, dynamic>{
+      ...context.vars,
+      'uses_firestore': firebaseAdditionalPackages.contains('cloud_firestore')
+    };
     await _generateApp(context);
     appGenerated.complete('Flutter App generated!');
   } catch (e) {


### PR DESCRIPTION
feat: add option to install firebase additional packages, add precompiled SDK when installing cloud_firestore

<!--
- add option to install firebase additional packages
- add precompiled IOS SDK to PodFile when installing cloud_firestore
-->

## Description

- add array option `firebase_packages` to choose to install additional firebase packages.
-  added `ios/Podfile` to generated files.
- updated `hooks/pre_gen.dart` to check if `cloud_firestore` is getting installed. If so, the precompiled FirebaseFirestore IOS SDK gets added to `ios/Podfile`
- updated `hooks/post_gen.dart` to iterate over all  firebase packages that need to be installed and put these in a `Future.wait` to process all commands.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
