### PR TITLE
feat: Allow selecting web app id

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -96,6 +96,14 @@ class ConfigCommand extends FlutterFireCommand {
           'automatically detect it from your "android" folder (if it exists).',
     );
     argParser.addOption(
+      'web-app-id',
+      valueHelp: 'appId',
+      abbr: 'w',
+      help: 'The app id of your Web application, e.g. "1:XXX:web:YYY". '
+          'If no package name is provided then an attempt will be made to '
+          'automatically pick the first available web app id from remote.',
+    );
+    argParser.addOption(
       'token',
       valueHelp: 'firebaseToken',
       abbr: 't',
@@ -195,6 +203,20 @@ class ConfigCommand extends FlutterFireCommand {
     final value = argResults!['ios-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
     return value;
+  }
+
+  String? get webAppId {
+    final value = argResults!['web-app-id'] as String?;
+
+    if (value != null) return value;
+
+    if (isCI) {
+      throw FirebaseCommandException(
+        'configure',
+        'Please provide value for web-app-id.',
+      );
+    }
+    return null;
   }
 
   String? get macosBundleId {
@@ -413,6 +435,7 @@ class ConfigCommand extends FlutterFireCommand {
         firebaseProjectId: selectedFirebaseProject.projectId,
         firebaseAccount: accountEmail,
         token: token,
+        webAppId: webAppId,
       );
     }
 

--- a/packages/flutterfire_cli/lib/src/firebase.dart
+++ b/packages/flutterfire_cli/lib/src/firebase.dart
@@ -226,6 +226,7 @@ Future<FirebaseApp> findOrCreateFirebaseApp({
   String? packageNameOrBundleIdentifier,
   String? account,
   String? token,
+  String? webAppId,
 }) async {
   var foundFirebaseApp = false;
   final displayNameWithPlatform = '$displayName ($platform)';
@@ -238,7 +239,7 @@ Future<FirebaseApp> findOrCreateFirebaseApp({
   final fetchingAppsSpinner = spinner(
     (done) {
       final loggingAppName =
-          packageNameOrBundleIdentifier ?? displayNameWithPlatform;
+          packageNameOrBundleIdentifier ?? webAppId ?? displayNameWithPlatform;
       if (!done) {
         return AnsiStyles.bold(
           'Fetching registered ${AnsiStyles.cyan(platform)} Firebase apps for project ${AnsiStyles.cyan(project)}',
@@ -279,14 +280,16 @@ Future<FirebaseApp> findOrCreateFirebaseApp({
   if (platform == kWeb && filteredFirebaseApps.isEmpty) {
     filteredFirebaseApps = unfilteredFirebaseApps.where(
       (firebaseApp) {
+        if (webAppId != null) {
+          return firebaseApp.appId == webAppId && firebaseApp.platform == kWeb;
+        }
+
         return firebaseApp.platform == kWeb;
       },
     );
   }
   foundFirebaseApp = filteredFirebaseApps.isNotEmpty;
   fetchingAppsSpinner.done();
-  // TODO in the case of web, if more than one found app then
-  // TODO we should maybe prompt to choose one.
   if (foundFirebaseApp) {
     return filteredFirebaseApps.first;
   }

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_web_options.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_web_options.dart
@@ -27,6 +27,7 @@ extension FirebaseWebOptions on FirebaseOptions {
     FlutterApp flutterApp, {
     required String firebaseProjectId,
     String? firebaseAccount,
+    String? webAppId,
     String platform = kWeb,
     required String? token,
   }) async {
@@ -36,6 +37,7 @@ extension FirebaseWebOptions on FirebaseOptions {
       project: firebaseProjectId,
       account: firebaseAccount,
       token: token,
+      webAppId: webAppId,
     );
     final appSdkConfig = await firebase.getAppSdkConfig(
       appId: firebaseApp.appId,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Add the option `web-app-id` to allow users to select which of the web apps they want to use. Didn't use `display-name` as that can easily be changed from Firebase's side, which could cause issues. 

#### Possible improvements
- Ask user to select when not in CI
- The behaviour used in this option can later be extrapolated to be used for linux and windows apps as well.

resolves #77 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
