### PR TITLE
fix: add GoogleService-Info.plist as bundle resource not compile source

### DIFF
--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -238,7 +238,7 @@ if googleConfigExists == false
   main_target = project.targets.find { |target| target.name == 'Runner' }
   
   if(main_target)
-    main_target.add_file_references([file])
+    main_target.add_resources([file])
     project.save
   else
     abort("Could not find target 'Runner' in your Xcode workspace. Please rename your target to 'Runner' and try again.")


### PR DESCRIPTION
## Description

When manually adding `GoogleService-Info.plist` to your XCode project, the file gets added to the project as a bundle resource file and gets added to the `Copy Bundle Resources` build phase for the target.

The Ruby script however was adding the file as a compile source file and as such was being added to the `Compile Sources` build phase for the target.

This was causing issues with macOS in #123 and this brings it in-line with the Firebase documentation and the expected way of adding `GoogleService-Info.plist` to the project.

Fixes #123.

## Type of Change


- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
