### PR TITLE
docs: Update README.md to not refer to the Flutter SDK for Firebase as FlutterFire anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/invertase/flutterfire_cli/blob/main/LICENSE">License</a>
 </p>
 
-A CLI to help with using [FlutterFire](https://firebase.flutter.dev) in your Flutter applications.
+A CLI to help with using [Firebase](https://firebase.google.com/docs/flutter) in your Flutter applications.
 
 ## Local development setup
 


### PR DESCRIPTION
## Description

Update to not refer to the Flutter SDK for Firebase as FlutterFire anymore, and to link to the official documentation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
