### PR TITLE
feat(cli): command line arguments for different environments

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -117,11 +117,45 @@ class ConfigCommand extends FlutterFireCommand {
           'and create the google-services.json file in your ./android/app folder.',
     );
     argParser.addFlag(
-      'debug-symbols-script',
-      hide: true,
-      abbr: 'd',
+      'debug-symbols-ios',
+      abbr: 'r',
       help:
           "Whether you want an upload Crashlytic's debug symbols script added to the build phases of your iOS project.",
+    );
+
+    argParser.addFlag(
+      'debug-symbols-macos',
+      abbr: 's',
+      help:
+          "Whether you want an upload Crashlytic's debug symbols script added to the build phases of your macOS project.",
+    );
+
+    argParser.addOption(
+      'ios-scheme',
+      valueHelp: 'iosSchemeName',
+      help:
+          'Name of iOS scheme to use for bundling `Google-Service-Info.plist` with your Xcode project',
+    );
+
+    argParser.addOption(
+      'macos-scheme',
+      valueHelp: 'macosSchemeName',
+      help:
+          'Name of macOS scheme to use for bundling `Google-Service-Info.plist` with your Xcode project',
+    );
+
+    argParser.addOption(
+      'ios-target',
+      valueHelp: 'iosTargetName',
+      help:
+          'Name of iOS target to use for bundling `Google-Service-Info.plist` with your Xcode project',
+    );
+
+    argParser.addOption(
+      'macos-target',
+      valueHelp: 'macosTargetName',
+      help:
+          'Name of macOS target to use for bundling `Google-Service-Info.plist` with your Xcode project',
     );
 
     argParser.addOption(
@@ -188,8 +222,28 @@ class ConfigCommand extends FlutterFireCommand {
     return argResults!['apply-gradle-plugins'] as bool;
   }
 
-  bool get generateDebugSymbolScript {
-    return argResults!['debug-symbols-script'] as bool;
+  bool get iosGenerateDebugSymbolScript {
+    return argResults!['debug-symbols-ios'] as bool;
+  }
+
+  bool get macosGenerateDebugSymbolScript {
+    return argResults!['debug-symbols-macos'] as bool;
+  }
+
+  String? get iosScheme {
+    return argResults!['ios-scheme'] as String?;
+  }
+
+  String? get macosScheme {
+    return argResults!['macos-scheme'] as String?;
+  }
+
+  String? get iosTarget {
+    return argResults!['ios-target'] as String?;
+  }
+
+  String? get macosTarget {
+    return argResults!['macos-target'] as String?;
   }
 
   String? get macosServiceFilePath {
@@ -427,10 +481,20 @@ class ConfigCommand extends FlutterFireCommand {
     return selectedPlatforms;
   }
 
+  void _checkTargetAndSchemeSetup() {
+    if (iosScheme != null && iosTarget != null) {
+      throw XcodeProjectException('ios');
+    }
+
+    if (macosScheme != null && macosTarget != null) {
+      throw XcodeProjectException('macos');
+    }
+  }
+
   @override
   Future<void> run() async {
     commandRequiresFlutterApp();
-
+    _checkTargetAndSchemeSetup();
     final selectedFirebaseProject = await _selectFirebaseProject();
     final selectedPlatforms = _selectPlatforms();
 
@@ -535,7 +599,9 @@ class ConfigCommand extends FlutterFireCommand {
         fulliOSServicePath,
         iosServiceFilePath,
         logger,
-        generateDebugSymbolScript,
+        iosGenerateDebugSymbolScript,
+        iosScheme,
+        iosTarget,
       ).apply();
     }
 
@@ -546,7 +612,9 @@ class ConfigCommand extends FlutterFireCommand {
         fullMacOSServicePath,
         macosServiceFilePath,
         logger,
-        generateDebugSymbolScript,
+        macosGenerateDebugSymbolScript,
+        macosScheme,
+        macosTarget,
       ).apply();
     }
 

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -178,6 +178,13 @@ class ConfigCommand extends FlutterFireCommand {
       help:
           'Where to write the `google-services.json` file to be written for android platform. Useful for different flavors',
     );
+
+    argParser.addFlag(
+      'overwrite-firebase-options',
+      abbr: 'f',
+      help:
+          "Rewrite the service file if you're running 'flutterfire configure' again due to updating project",
+    );
   }
 
   @override
@@ -330,6 +337,10 @@ class ConfigCommand extends FlutterFireCommand {
 
   String get outputFilePath {
     return argResults!['out'] as String;
+  }
+
+  bool? get overwriteFirebaseOptions {
+    return argResults!['overwrite-firebase-options'] as bool?;
   }
 
   String get iosAppIDOutputFilePrefix {
@@ -580,6 +591,7 @@ class ConfigCommand extends FlutterFireCommand {
       windowsOptions: windowsOptions,
       linuxOptions: linuxOptions,
       force: isCI || yes,
+      overwriteFirebaseOptions: overwriteFirebaseOptions,
     );
     futures.add(configFile.write());
 

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -229,11 +229,11 @@ class ConfigCommand extends FlutterFireCommand {
     return argResults!['apply-gradle-plugins'] as bool;
   }
 
-  bool get iosGenerateDebugSymbolScript {
+  bool? get iosGenerateDebugSymbolScript {
     return argResults!['debug-symbols-ios'] as bool;
   }
 
-  bool get macosGenerateDebugSymbolScript {
+  bool? get macosGenerateDebugSymbolScript {
     return argResults!['debug-symbols-macos'] as bool;
   }
 

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -119,6 +119,7 @@ class ConfigCommand extends FlutterFireCommand {
     argParser.addFlag(
       'debug-symbols-ios',
       abbr: 'r',
+      defaultsTo: null,
       help:
           "Whether you want an upload Crashlytic's debug symbols script added to the build phases of your iOS project.",
     );
@@ -126,6 +127,7 @@ class ConfigCommand extends FlutterFireCommand {
     argParser.addFlag(
       'debug-symbols-macos',
       abbr: 's',
+      defaultsTo: null,
       help:
           "Whether you want an upload Crashlytic's debug symbols script added to the build phases of your macOS project.",
     );
@@ -182,6 +184,7 @@ class ConfigCommand extends FlutterFireCommand {
     argParser.addFlag(
       'overwrite-firebase-options',
       abbr: 'f',
+      defaultsTo: null,
       help:
           "Rewrite the service file if you're running 'flutterfire configure' again due to updating project",
     );
@@ -230,11 +233,11 @@ class ConfigCommand extends FlutterFireCommand {
   }
 
   bool? get iosGenerateDebugSymbolScript {
-    return argResults!['debug-symbols-ios'] as bool;
+    return argResults!['debug-symbols-ios'] as bool?;
   }
 
   bool? get macosGenerateDebugSymbolScript {
-    return argResults!['debug-symbols-macos'] as bool;
+    return argResults!['debug-symbols-macos'] as bool?;
   }
 
   String? get iosScheme {

--- a/packages/flutterfire_cli/lib/src/common/strings.dart
+++ b/packages/flutterfire_cli/lib/src/common/strings.dart
@@ -90,6 +90,40 @@ const logSkippingGradleFilesUpdate =
 /// A base class for all FlutterFire CLI exceptions.
 abstract class FlutterFireException implements Exception {}
 
+/// An exception that is thrown when a "[ios || macos]-target" & a "[ios || macos]-scheme" have both been used as command
+/// line arguments
+class XcodeProjectException implements FlutterFireException {
+  XcodeProjectException(this.platform) : super();
+
+  final String platform;
+
+  @override
+  String toString() {
+    return 'XcodeProjectException: choose either a "$platform-target" or a "$platform-scheme" for your $platform project setup';
+  }
+}
+
+/// An exception that is thrown when you have selected a name for your scheme or target that does not exist on your project
+class MissingFromXcodeProjectException implements FlutterFireException {
+  MissingFromXcodeProjectException(
+    this.platform,
+    this.type,
+    this.name,
+    this.listOfChoices,
+  ) : super();
+
+  final String platform;
+  // Type is either "scheme" or "target"
+  final String type;
+  final String name;
+  final List<String> listOfChoices;
+
+  @override
+  String toString() {
+    return 'MissingFromXcodeProjectException: The $name does not exist as a $type for your $platform project. Please choose from one of the following: ${listOfChoices.join(', ')} ';
+  }
+}
+
 /// An exception that is thrown when the configure command is ran in a directory
 /// that is not a Flutter project.
 class FlutterAppRequiredException implements FlutterFireException {

--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -362,21 +362,26 @@ Future<void> writeToTargetProject(
 }
 
 Future<void> writeDebugSymbolScriptForScheme(
-  bool generateDebugSymbolScript,
+  bool? generateDebugSymbolScript,
   String xcodeProjFilePath,
   String appId,
   Logger logger,
   String name,
   String platform,
 ) async {
-  if (generateDebugSymbolScript) {
+  // ignore: use_if_null_to_convert_nulls_to_bools
+  if (generateDebugSymbolScript == true) {
     await writeDebugScriptForScheme(
       xcodeProjFilePath,
       appId,
       name,
       logger,
     );
+  } else if (generateDebugSymbolScript == false) {
+    // User has specifically requested no debug symbol script insert.
+    return;
   } else {
+    // User hasn't specified anything, so we prompt
     final addSymbolScript = promptBool(
       "Do you want an 'upload Crashlytic's debug symbols script' adding to the build phases of your $platform project's '$name' scheme?",
     );
@@ -397,21 +402,26 @@ Future<void> writeDebugSymbolScriptForScheme(
 }
 
 Future<void> writeDebugSymbolScriptForTarget(
-  bool generateDebugSymbolScript,
+  bool? generateDebugSymbolScript,
   String xcodeProjFilePath,
   String appId,
   Logger logger,
   String name,
   String platform,
 ) async {
-  if (generateDebugSymbolScript) {
+  // ignore: use_if_null_to_convert_nulls_to_bools
+  if (generateDebugSymbolScript == true) {
     await writeDebugScriptForTarget(
       xcodeProjFilePath,
       appId,
       name,
       logger,
     );
+  } else if (generateDebugSymbolScript == false) {
+    // User has specifically requested no debug symbol script insert.
+    return;
   } else {
+    // User hasn't specified anything, so we prompt
     final addSymbolScript = promptBool(
       "Do you want an 'upload Crashlytic's debug symbols script' adding to the build phases of your $platform project's '$name' target?",
     );

--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -582,7 +582,7 @@ GOOGLESERVICE_INFO_PATH=\${GOOGLESERVICE_INFO_PATH}/$googleServiceFilePath
 # Copy GoogleService-Info.plist for appropriate scheme. Each scheme has multiple configurations (i.e. Debug-development, Debug-staging, etc).
 # This is why we use *"scheme"*
 # If scheme is "Runner", it is the default scheme for a Flutter iOS project so we allow for all configurations
-if [[ "\${CONFIGURATION}" == *"$scheme"* ||  "Runner" = "$scheme" ]];
+if [[ ("\${CONFIGURATION}" == *"$scheme"*) ||  ("Runner" = "$scheme") ]];
 then
     echo "Copying \${GOOGLESERVICE_INFO_PATH} to \${PLIST_DESTINATION}"
     cp "\${GOOGLESERVICE_INFO_PATH}" "\${PLIST_DESTINATION}"
@@ -623,7 +623,7 @@ bashScript = %q(
 
 # Run upload symbol script for appropriate scheme. Each scheme has multiple configurations (i.e. Debug-development, Debug-staging, etc).
 # This is why we use *"scheme"*
-if [ "\${CONFIGURATION}" == *"$scheme"* && -f \$PODS_ROOT/FirebaseCrashlytics/upload-symbols];
+if [[ ("\${CONFIGURATION}" == *"$scheme"*) && (-f \$PODS_ROOT/FirebaseCrashlytics/upload-symbols)]];
 then
     echo "Running $runScriptName"
     \$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase --validate -ai '$appId'
@@ -669,7 +669,7 @@ bashScript = %q(
 #!/bin/bash
 
 # Run upload symbol script for appropriate target.
-if [ "\${TARGET_NAME}" == "$target" && -f \$PODS_ROOT/FirebaseCrashlytics/upload-symbols];
+if [[ ("\${TARGET_NAME}" == "$target") && (-f \$PODS_ROOT/FirebaseCrashlytics/upload-symbols)]];
 then
     echo "Running $runScriptName"
     \$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase --validate -ai '$appId'

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
@@ -33,6 +33,7 @@ class FirebaseConfigurationFile {
     this.webOptions,
     this.windowsOptions,
     this.linuxOptions,
+    this.overwriteFirebaseOptions,
     this.force = false,
   });
 
@@ -42,6 +43,8 @@ class FirebaseConfigurationFile {
 
   /// Whether to skip prompts and force write output file.
   final bool force;
+
+  final bool? overwriteFirebaseOptions;
 
   FirebaseOptions? webOptions;
 
@@ -68,11 +71,13 @@ class FirebaseConfigurationFile {
       // Only prompt overwrite if contents have changed.
       // Trimming since some IDEs/git auto apply a trailing newline.
       if (existingFileContents.trim() != newFileContents.trim()) {
-        final shouldOverwrite = promptBool(
-          'Generated FirebaseOptions file ${AnsiStyles.cyan(outputFilePath)} already exists, do you want to override it?',
-        );
-        if (!shouldOverwrite) {
-          throw FirebaseOptionsAlreadyExistsException(outputFilePath);
+        if (overwriteFirebaseOptions != true) {
+          final shouldOverwrite = promptBool(
+            'Generated FirebaseOptions file ${AnsiStyles.cyan(outputFilePath)} already exists, do you want to override it?',
+          );
+          if (!shouldOverwrite) {
+            throw FirebaseOptionsAlreadyExistsException(outputFilePath);
+          }
         }
       }
     }

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
@@ -63,7 +63,7 @@ class FirebaseConfigurationFile {
     final fileExists = outputFile.existsSync();
 
     // If the user specifically chooses to negate overwriting the file, return immediately
-    if(fileExists && overwriteFirebaseOptions == false) return;
+    if (fileExists && overwriteFirebaseOptions == false) return;
 
     // Write buffer early so we can string compare contents if file exists already.
     _writeHeader();

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_configuration_file.dart
@@ -60,17 +60,22 @@ class FirebaseConfigurationFile {
 
   Future<void> write() async {
     final outputFile = File(joinAll([Directory.current.path, outputFilePath]));
+    final fileExists = outputFile.existsSync();
+
+    // If the user specifically chooses to negate overwriting the file, return immediately
+    if(fileExists && overwriteFirebaseOptions == false) return;
 
     // Write buffer early so we can string compare contents if file exists already.
     _writeHeader();
     _writeClass();
     final newFileContents = _stringBuffer.toString();
 
-    if (outputFile.existsSync() && !force) {
+    if (fileExists && !force) {
       final existingFileContents = await outputFile.readAsString();
       // Only prompt overwrite if contents have changed.
       // Trimming since some IDEs/git auto apply a trailing newline.
       if (existingFileContents.trim() != newFileContents.trim()) {
+        // If the user chooses this option, they want it overwritten so no need to prompt
         if (overwriteFirebaseOptions != true) {
           final shouldOverwrite = promptBool(
             'Generated FirebaseOptions file ${AnsiStyles.cyan(outputFilePath)} already exists, do you want to override it?',

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
@@ -48,11 +48,11 @@ class FirebaseIOSSetup {
     if (scheme != null && fulliOSServicePath == null) {
       // if the user has selected a  scheme but no "ios-out" argument, they need to specify the location of "GoogleService-Info.plist" so it can be used at build time.
       // No need to do the same for target as it is included with bundle resources
-
       final pathToServiceFile = promptInput(
         'Enter a path for your iOS "GoogleService-Info.plist" ("ios-out" argument.) file in your Flutter project. It is required if you set "ios-scheme" argument. Example input: ios/dev',
         validator: (String x) {
-          if (RegExp(r'^(?![#\/.])(?!.*[#\/.]$).*').hasMatch(x) && !path.basename(x).contains('.')) {
+          if (RegExp(r'^(?![#\/.])(?!.*[#\/.]$).*').hasMatch(x) &&
+              !path.basename(x).contains('.')) {
             return true;
           } else {
             return 'Do not start or end path with a backslash, nor specify the filename. Example: ios/dev';
@@ -63,7 +63,8 @@ class FirebaseIOSSetup {
       fulliOSServicePath =
           '${flutterApp!.package.path}/$pathToServiceFile/${iosOptions.optionsSourceFileName}';
 
-      relativeiOSServiceFilePath = '$pathToServiceFile/${iosOptions.optionsSourceFileName}';
+      relativeiOSServiceFilePath =
+          '$pathToServiceFile/${iosOptions.optionsSourceFileName}';
 
       await Directory(path.dirname(fulliOSServicePath!))
           .create(recursive: true);

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
@@ -26,7 +26,7 @@ class FirebaseIOSSetup {
   String? fulliOSServicePath;
   String? iosServiceFilePath;
   final Logger logger;
-  final bool generateDebugSymbolScript;
+  final bool? generateDebugSymbolScript;
 // This allows us to update to the required "GoogleService-Info.plist" file name for iOS target or scheme writes.
   String? updatedIOSServiceFilePath;
   String? scheme;

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
@@ -47,7 +47,7 @@ class FirebaseIOSSetup {
 
     if (scheme != null && fulliOSServicePath == null) {
       // if the user has selected a  scheme but no "ios-out" argument, they need to specify the location of "GoogleService-Info.plist" so it can be used at build time.
-      // No need to do the same for target as it is included with bundle resources
+      // No need to do the same for target as it is included with bundle resources and included in Runner directory
       final pathToServiceFile = promptInput(
         'Enter a path for your iOS "GoogleService-Info.plist" ("ios-out" argument.) file in your Flutter project. It is required if you set "ios-scheme" argument. Example input: ios/dev',
         validator: (String x) {

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_ios_setup.dart
@@ -55,7 +55,7 @@ class FirebaseIOSSetup {
               !path.basename(x).contains('.')) {
             return true;
           } else {
-            return 'Do not start or end path with a backslash, nor specify the filename. Example: ios/dev';
+            return 'Do not start or end path with a forward slash, nor specify the filename. Example: ios/dev';
           }
         },
       );

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
@@ -53,7 +53,7 @@ class FirebaseMacOSSetup {
               !path.basename(x).contains('.')) {
             return true;
           } else {
-            return 'Do not start or end path with a backslash, nor specify the filename. Example: macos/dev';
+            return 'Do not start or end path with a forward slash, nor specify the filename. Example: macos/dev';
           }
         },
       );

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
@@ -26,7 +26,7 @@ class FirebaseMacOSSetup {
   String? fullMacOSServicePath;
   String? macosServiceFilePath;
   final Logger logger;
-  final bool generateDebugSymbolScript;
+  final bool? generateDebugSymbolScript;
   String? scheme;
   String? target;
 

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_macos_setup.dart
@@ -45,7 +45,7 @@ class FirebaseMacOSSetup {
 
     if (scheme != null && fullMacOSServicePath == null) {
       // if the user has selected a  scheme but no "macos-out" argument, they need to specify the location of "GoogleService-Info.plist" so it can be used at build time.
-      // No need to do the same for target as it is included with bundle resources
+      // No need to do the same for target as it is included with bundle resources and included in Runner directory
       final pathToServiceFile = promptInput(
         'Enter a relative path for your macOS "${macosOptions.optionsSourceFileName}" ("macos-out" argument.) file in your Flutter project. It is required if you set "macos-scheme" argument. Example input: macos/dev',
         validator: (String x) {


### PR DESCRIPTION
## Description

Created command line arguments which negate the need to use the command prompts. The following command line arguments have been added:

1. `ios-scheme` - pass in the name of the scheme you wish to use for your iOS project.
2. `macos-scheme` - pass in the name of the scheme you wish to use for your macOS project.
3. `ios-target`- - pass in the name of the target you wish to use for your iOS project.
4. `macos-target`- - pass in the name of the target you wish to use for your macOS project.
5. `debug-symbols-ios` - This is a command line flag.  It will add an upload debug symbols script to your iOS target or scheme (depending on whether you used `ios-scheme` or `ios-target`). This replaces `debug-symbols-script` which was a hidden flag in the last dev release. If you choose to negate the script (i.e. `no-debug-symbol-ios`), you will not be prompted asking if you wish to write it.
6. `debug-symbols-macos` - This is a command line flag.  It will add an upload debug symbols script to your macOS target or scheme (depending on whether you used `macos-scheme` or `macos-target`). If you choose to negate the script (i.e. `no-debug-symbol-macos`), you will not be prompted asking if you wish to write it.
7. `overwrite-firebase-options` - This is a command line flag. This allows you to overwrite/not overwrite the current `firebase_options.dart` if you're running `flutterfire configure` again. If you choose to negate it (i.e. `no-overwrite-firebase-options`), you will not be prompted asking if you wish to write it.

## Notes
1. You can only set either `ios-scheme` OR `ios-target`. If you try to set both, the script will throw an error.
2. You can only set either `macos-scheme` OR `macos-target`. If you try to set both, the script will throw an error. 
3. If you choose `ios-scheme` or `macos-scheme` setup, you have to specify a path for `ios-out` or `macos-out`. If you don't, you will be prompted by the CLI for a path. This is because it is included in the app bundle at build time, and there needs to be a "GoogleService-Info.plist" in the project directory to use. If you choose the "target" method (i.e. `ios-target` or `macos-target`), you do not have to specify a path for "GoogleService-Info.plist" file if you wish (i.e. `ios-out` or `macos-out`). This is because the CLI will add the "GoogleService-Info.plist" file to the bundle resources, and it will automatically place the file under the target (e.g. `Runner/GoogleService-Info.plist`). 
4. I have fixed the conditions used on Bash scripts for build run phases.

## Examples of commands that completely negate any user input from prompts:


Note, it is required to specify the Firebase project via `--project` argument.  You also need to include the `--yes` flag which does a few things. It will automatically choose all platforms on your project (e.g. iOS, macOS, android & web), will overwrite `firebase_options.dart` (can also use `--overwrite-firebase-options` for this specific task), it will also force write necessary updates to android `build.gradle`'s for FlutterFire configuration.

```bash
flutterfire configure --ios-target=Runner  --android-out=/android/app/src/debug/google-services.json --debug-symbols-ios --debug-symbols-macos  --macos-target=Runner --yes --project=firebase-project
```

 Note, the debug symbols scripts are not being written, nor is `firebase_options.dart` being overwritten. I also removed `android-out` argument to demonstrate that by default, it will write to `android/app/google-services.json` as usual.

```bash
flutterfire configure --ios-target=Runner --no-debug-symbols-ios --no-debug-symbols-macos  --macos-target=Runner --no-overwrite-firebase-options --yes --project=firebase-project
```

Note, I was using VGV's CLI to create a project for testing as it has different schemes setup from the beginning (i.e. development, staging, production). macOS schemes will be fixed in a future release, so we use the target again here.

```bash
flutterfire configure --ios-scheme=development --ios-out=ios/dev/GoogleService-Info.plist --debug-symbols-ios --debug-symbols-macos  --macos-target=Runner --no-overwrite-firebase-options --yes --project=firebase-project
``` 


## Related issues

Part of: https://github.com/invertase/flutterfire_cli/issues/14

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
