### PR TITLE
fix: failing to parse an existing google-services.json file throws exception

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_gradle_plugins.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_gradle_plugins.dart
@@ -112,12 +112,17 @@ class FirebaseAndroidGradlePlugins {
     var existingProjectId = '';
     var shouldPromptOverwriteGoogleServicesJson = false;
     if (androidGoogleServicesJsonFile.existsSync()) {
-      final existingGoogleServicesJsonContents =
-          await androidGoogleServicesJsonFile.readAsString();
-      existingProjectId = FirebaseAndroidOptions.projectIdFromFileContents(
-        existingGoogleServicesJsonContents,
-      );
-      if (existingProjectId != firebaseOptions.projectId) {
+      final existingGoogleServicesJsonContents = await androidGoogleServicesJsonFile.readAsString();
+
+      try {
+        existingProjectId = FirebaseAndroidOptions.projectIdFromFileContents(
+          existingGoogleServicesJsonContents,
+        );
+        if (existingProjectId != firebaseOptions.projectId) {
+          shouldPromptOverwriteGoogleServicesJson = true;
+        }
+      } catch (e) {
+        // parsing of existing google services file failed.
         shouldPromptOverwriteGoogleServicesJson = true;
       }
     }


### PR DESCRIPTION
## Description

A google-services.json file may exist but may not always be able to be parsed for a number of reasons such as an empty file, or corrupt content.

Rather than throwing an exception and aborting the command, if an exception occurs while trying to extract to parse the existing google-services.json file, we now prompt the user to overwrite the file.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
