### PR TITLE
fix: configure command not updating build.gradle files

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_gradle_plugins.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_gradle_plugins.dart
@@ -10,7 +10,7 @@ import 'firebase_options.dart';
 
 // https://regex101.com/r/w2ovos/1
 final _androidBuildGradleRegex = RegExp(
-  r'''(?:\s*?dependencies\s?{$\n(?<indentation>[\s\S\w]*?)classpath\s?['"]{1}com\.android\.tools\.build:gradle:.*?['"]{1}\s*?$)''',
+  r'''(?:(?<indentation>^[\s]*?)classpath\s?['"]{1}com\.android\.tools\.build:gradle:.*?['"]{1}\s*?$)''',
   multiLine: true,
 );
 // https://regex101.com/r/rbfAdd/1
@@ -157,7 +157,7 @@ class FirebaseAndroidGradlePlugins {
     androidBuildGradleFileContents = androidBuildGradleFileContents
         .replaceFirstMapped(_androidBuildGradleRegex, (match) {
       final indentation = match.group(1);
-      return '${match.group(0)}\n$indentation$_flutterFireConfigCommentStart\n$indentation$_googleServicesPlugin\n$indentation$_flutterFireConfigCommentEnd';
+      return '${match.group(0)}$indentation$_flutterFireConfigCommentStart$indentation$_googleServicesPlugin$indentation$_flutterFireConfigCommentEnd';
     });
 
     if (!androidAppBuildGradleFileContents


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
The issue for this bug was that the `_androidBuildGradleRegex` regex expression was failing when it tried to match against the document, hence it would have failed even in the `replaceFirstMapped()` method later on in the code.

Changed the regex to capture only the `classpath 'com.android.tools.build:gradle:7.1.2'` with the indentation included, and also modified the `replaceFirstMapped()` accordingly.

closes issue #126

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
