### PR TITLE
ci(*): use `dart format` instead of `flutter format`

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -22,8 +22,8 @@ scripts:
         - "*monorepo*"
 
   format-check:
-    run: melos exec flutter format . --set-exit-if-changed
-    description: Run `flutter format` checks for all packages.
+    run: melos exec dart format . --set-exit-if-changed
+    description: Run `dart format` checks for all packages.
     select-package:
       ignore:
         - "flutterfire_starter"


### PR DESCRIPTION
## Description

`flutter format` shouldn't be used anymore:

```
[!] The "format" command is deprecated and will be removed in a future version of Flutter. Please use the "dart format" sub-command instead,
which takes all of the same command-line arguments as "flutter format".
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [x] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
