### PR TITLE
feat: overwrite Apple service files if they exist already.

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -486,6 +486,7 @@ class ConfigCommand extends FlutterFireCommand {
 
     final firebaseConfigurationFileInputs = dartConfigurationFileValidation(
       flutterAppPath: flutterApp!.package.path,
+      overwrite: yes,
     );
 
     final selectedFirebaseProject = await _selectFirebaseProject();

--- a/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
+++ b/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
@@ -248,21 +248,24 @@ class Reconfigure extends FlutterFireCommand {
               );
               break;
             case kIos:
-              configWrite.iosOptions = FirebaseAppleOptions.convertConfigToOptions(
+              configWrite.iosOptions =
+                  FirebaseAppleOptions.convertConfigToOptions(
                 appSdkConfig,
                 appId,
                 projectId,
               );
               break;
             case kMacos:
-              configWrite.macosOptions = FirebaseAppleOptions.convertConfigToOptions(
+              configWrite.macosOptions =
+                  FirebaseAppleOptions.convertConfigToOptions(
                 appSdkConfig,
                 appId,
                 projectId,
               );
               break;
             case kWeb:
-              configWrite.webOptions = FirebaseDartOptions.convertConfigToOptions(
+              configWrite.webOptions =
+                  FirebaseDartOptions.convertConfigToOptions(
                 appSdkConfig,
                 projectId,
               );

--- a/packages/flutterfire_cli/lib/src/common/strings.dart
+++ b/packages/flutterfire_cli/lib/src/common/strings.dart
@@ -64,9 +64,6 @@ const logLearnMoreAboutCli =
     'Learn more about using this file and next steps from the documentation:\n'
     ' > $firebaseDocumentationUrl';
 
-const serviceFileAlreadyExists =
-    'Your $appleServiceFileName already exists, skipping write... ';
-
 /// Prompts when Android Google Services JSON file already exists but contains
 /// configuration values for a different Firebase project.
 String logPromptReplaceGoogleServicesJson(

--- a/packages/flutterfire_cli/lib/src/common/validation.dart
+++ b/packages/flutterfire_cli/lib/src/common/validation.dart
@@ -125,7 +125,7 @@ AndroidInputs androidValidation({
 DartConfigurationFileInputs dartConfigurationFileValidation({
   String? configurationFilePath,
   required String flutterAppPath,
-  required bool overwrite
+  required bool overwrite,
 }) {
   final validatedConfigurationFilePath = configurationFilePath == null
       // Default service file path
@@ -134,9 +134,10 @@ DartConfigurationFileInputs dartConfigurationFileValidation({
           configurationFilePath: configurationFilePath,
           flutterAppPath: flutterAppPath,
         );
-  final writeConfigurationFile = overwrite || promptWriteConfigurationFile(
-    configurationFilePath: validatedConfigurationFilePath,
-  );
+  final writeConfigurationFile = overwrite ||
+      promptWriteConfigurationFile(
+        configurationFilePath: validatedConfigurationFilePath,
+      );
 
   return DartConfigurationFileInputs(
     configurationFilePath: validatedConfigurationFilePath,

--- a/packages/flutterfire_cli/lib/src/common/validation.dart
+++ b/packages/flutterfire_cli/lib/src/common/validation.dart
@@ -125,6 +125,7 @@ AndroidInputs androidValidation({
 DartConfigurationFileInputs dartConfigurationFileValidation({
   String? configurationFilePath,
   required String flutterAppPath,
+  required bool overwrite
 }) {
   final validatedConfigurationFilePath = configurationFilePath == null
       // Default service file path
@@ -133,7 +134,7 @@ DartConfigurationFileInputs dartConfigurationFileValidation({
           configurationFilePath: configurationFilePath,
           flutterAppPath: flutterAppPath,
         );
-  final writeConfigurationFile = promptWriteConfigurationFile(
+  final writeConfigurationFile = overwrite || promptWriteConfigurationFile(
     configurationFilePath: validatedConfigurationFilePath,
   );
 

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_setup.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_setup.dart
@@ -93,17 +93,21 @@ file = project.new_file(googleFile)
 target = project.targets.find { |target| target.name == targetName }
 
 if(target)
-  exists = target.resources_build_phase.files.find do |file|
+  existingServiceFile = target.resources_build_phase.files.find do |file|
     if defined? file && file.file_ref && file.file_ref.path
       if file.file_ref.path.is_a? String
         file.file_ref.path.include? 'GoogleService-Info.plist'
       end
     end
-  end  
-  if !exists
-    target.add_resources([file])
-    project.save
   end
+  
+  if existingServiceFile
+    existingServiceFile.remove_from_project
+  end 
+
+  target.add_resources([file])
+  project.save
+  
 else
   abort("Could not find target: \$targetName in your Xcode workspace. Please create a target named \$targetName and try again.")
 end  
@@ -431,11 +435,7 @@ end
   Future<void> _writeGoogleServiceFileToPath() async {
     final file = await _createServiceFileToSpecifiedPath();
 
-    if (!file.existsSync()) {
-      await file.writeAsString(platformOptions.optionsSourceContent);
-    } else {
-      logger.stdout(serviceFileAlreadyExists);
-    }
+    await file.writeAsString(platformOptions.optionsSourceContent);
   }
 
   Future<FirebaseJsonWrites> apply();

--- a/packages/flutterfire_cli/test/configure_test.dart
+++ b/packages/flutterfire_cli/test/configure_test.dart
@@ -45,7 +45,11 @@ void main() {
             p.join(projectPath!, kIos, defaultTarget, appleServiceFileName);
         final macosPath = p.join(projectPath!, kMacos, defaultTarget);
 
-        await testAppleServiceFileValues(iosPath, macosPath);
+        await testAppleServiceFileValues(iosPath);
+        await testAppleServiceFileValues(
+          macosPath,
+          platform: kMacos,
+        );
 
         // check default "firebase.json" was created and has correct content
         final firebaseJsonFile = p.join(projectPath!, 'firebase.json');
@@ -234,7 +238,11 @@ void main() {
           buildType,
         );
 
-        await testAppleServiceFileValues(iosPath, macosPath);
+        await testAppleServiceFileValues(iosPath);
+        await testAppleServiceFileValues(
+          macosPath,
+          platform: kMacos,
+        );
 
         // check default "firebase.json" was created and has correct content
         final firebaseJsonFile = p.join(projectPath!, 'firebase.json');
@@ -418,7 +426,11 @@ void main() {
             p.join(projectPath!, kIos, applePath, appleServiceFileName);
         final macosPath = p.join(projectPath!, kMacos, applePath);
 
-        await testAppleServiceFileValues(iosPath, macosPath);
+        await testAppleServiceFileValues(iosPath);
+        await testAppleServiceFileValues(
+          macosPath,
+          platform: kMacos,
+        );
 
         // check default "firebase.json" was created and has correct content
         final firebaseJsonFile = p.join(projectPath!, 'firebase.json');
@@ -691,7 +703,12 @@ void main() {
 
         await testAppleServiceFileValues(
           iosPath,
+          appId: secondAppleAppId,
+          bundleId: secondAppleBundleId,
+        );
+        await testAppleServiceFileValues(
           macosPath,
+          platform: kMacos,
           appId: secondAppleAppId,
           bundleId: secondAppleBundleId,
         );

--- a/packages/flutterfire_cli/test/reconfigure_test.dart
+++ b/packages/flutterfire_cli/test/reconfigure_test.dart
@@ -104,7 +104,11 @@ void main() {
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
 
       if (Platform.isMacOS) {
-        await testAppleServiceFileValues(iosPath!, macosPath!);
+        await testAppleServiceFileValues(iosPath!);
+        await testAppleServiceFileValues(
+          macosPath!,
+          platform: kMacos,
+        );
       }
     },
     timeout: const Timeout(
@@ -188,7 +192,11 @@ void main() {
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
 
       if (Platform.isMacOS) {
-        await testAppleServiceFileValues(iosPath!, macosPath!);
+        await testAppleServiceFileValues(iosPath!);
+        await testAppleServiceFileValues(
+          macosPath!,
+          platform: kMacos,
+        );
       }
     },
     timeout: const Timeout(
@@ -275,7 +283,11 @@ void main() {
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
 
       if (Platform.isMacOS) {
-        await testAppleServiceFileValues(iosPath!, macosPath!);
+        await testAppleServiceFileValues(iosPath!);
+        await testAppleServiceFileValues(
+          macosPath!,
+          platform: kMacos,
+        );
       }
     },
     timeout: const Timeout(

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -256,12 +256,12 @@ void checkAppleFirebaseJsonValues(
   String pathToServiceFile, {
   String? appId = appleAppId,
 }) {
-  final iosDefaultConfig = getNestedMap(decodedFirebaseJson, keysToAppleMap);
-  expect(iosDefaultConfig[kAppId], appId);
-  expect(iosDefaultConfig[kProjectId], firebaseProjectId);
-  expect(iosDefaultConfig[kUploadDebugSymbols], false);
+  final appleDefaultConfig = getNestedMap(decodedFirebaseJson, keysToAppleMap);
+  expect(appleDefaultConfig[kAppId], appId);
+  expect(appleDefaultConfig[kProjectId], firebaseProjectId);
+  expect(appleDefaultConfig[kUploadDebugSymbols], false);
   expect(
-    iosDefaultConfig[kFileOutput],
+    appleDefaultConfig[kFileOutput],
     pathToServiceFile,
   );
 }

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -179,7 +179,6 @@ String? getValue(XmlElement dictionary, String key) {
   return valueElement?.innerText;
 }
 
-// TODO - we can update this for both apple platforms
 Future<void> testAppleServiceFileValues(
   String applePath,
   // ios or macos

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -12,6 +12,13 @@ const appleAppId = '1:262904632156:ios:58c61e319713c6142f2799';
 const androidAppId = '1:262904632156:android:eef79d5fec9aab142f2799';
 const webAppId = '1:262904632156:web:22fdf07f28e76b062f2799';
 
+// Secondary App Ids
+const secondAppleAppId = '1:262904632156:ios:1de2ea53918d5e802f2799';
+const secondAndroidAppId = '1:262904632156:android:efaa8538e6d346502f2799';
+const secondWebAppId = '1:262904632156:web:22fdf07f28e76b062f2799';
+
+const secondAppleBundleId = 'com.example.secondApp';
+
 const buildType = 'development';
 const appleBuildConfiguration = 'Debug';
 
@@ -172,10 +179,13 @@ String? getValue(XmlElement dictionary, String key) {
   return valueElement?.innerText;
 }
 
+// TODO - we can update this for both apple platforms
 Future<void> testAppleServiceFileValues(
   String iosPath,
-  String macosPath,
-) async {
+  String macosPath, {
+  String? bundleId = appleBundleId,
+  String? appId = appleAppId,
+}) async {
   // Need to find mac file like this for it to work on CI. No idea why.
   final macFile = await findFileInDirectory(macosPath, appleServiceFileName);
 
@@ -195,8 +205,8 @@ Future<void> testAppleServiceFileValues(
   final iosGcmSenderId = getValue(iosDictionary, 'GCM_SENDER_ID');
 
   expect(iosProjectId, firebaseProjectId);
-  expect(iosBundleId, appleBundleId);
-  expect(iosGoogleAppId, appleAppId);
+  expect(iosBundleId, bundleId);
+  expect(iosGoogleAppId, appId);
   expect(iosApiKey, appleApiKey);
   expect(iosGcmSenderId, appleGcmSenderId);
 
@@ -209,13 +219,16 @@ Future<void> testAppleServiceFileValues(
   final macosGcmSenderId = getValue(macosDictionary, 'GCM_SENDER_ID');
 
   expect(macosProjectId, firebaseProjectId);
-  expect(macosBundleId, appleBundleId);
-  expect(macosGoogleAppId, appleAppId);
+  expect(macosBundleId, bundleId);
+  expect(macosGoogleAppId, appId);
   expect(macosApiKey, appleApiKey);
   expect(macosGcmSenderId, appleGcmSenderId);
 }
 
-void testAndroidServiceFileValues(String serviceFilePath) {
+void testAndroidServiceFileValues(
+  String serviceFilePath, {
+  String? appId = androidAppId,
+}) {
   final clientList = Map<String, dynamic>.from(
     jsonDecode(File(serviceFilePath).readAsStringSync())
         as Map<String, dynamic>,
@@ -225,7 +238,7 @@ void testAndroidServiceFileValues(String serviceFilePath) {
       List<Map<String, dynamic>>.from(clientList['client'] as List<dynamic>)
           .firstWhere(
     // ignore: avoid_dynamic_calls
-    (element) => element['client_info']['mobilesdk_app_id'] == androidAppId,
+    (element) => element['client_info']['mobilesdk_app_id'] == appId,
   );
 
   expect(findClientMap, isA<Map<String, dynamic>>());
@@ -248,13 +261,14 @@ Future<void> testFirebaseOptionsFileValues(
   expect(firebaseOptionsContent, testFirebaseOptionsContent);
 }
 
-void checkIosFirebaseJsonValues(
+void checkAppleFirebaseJsonValues(
   Map<String, dynamic> decodedFirebaseJson,
-  List<String> keysToMapIos,
-  String pathToServiceFile,
-) {
-  final iosDefaultConfig = getNestedMap(decodedFirebaseJson, keysToMapIos);
-  expect(iosDefaultConfig[kAppId], appleAppId);
+  List<String> keysToAppleMap,
+  String pathToServiceFile, {
+  String? appId = appleAppId,
+}) {
+  final iosDefaultConfig = getNestedMap(decodedFirebaseJson, keysToAppleMap);
+  expect(iosDefaultConfig[kAppId], appId);
   expect(iosDefaultConfig[kProjectId], firebaseProjectId);
   expect(iosDefaultConfig[kUploadDebugSymbols], false);
   expect(
@@ -263,29 +277,15 @@ void checkIosFirebaseJsonValues(
   );
 }
 
-void checkMacosFirebaseJsonValues(
-  Map<String, dynamic> decodedFirebaseJson,
-  List<String> keysToMapMacos,
-  String pathToServiceFile,
-) {
-  final macosDefaultConfig = getNestedMap(decodedFirebaseJson, keysToMapMacos);
-  expect(macosDefaultConfig[kAppId], appleAppId);
-  expect(macosDefaultConfig[kProjectId], firebaseProjectId);
-  expect(macosDefaultConfig[kUploadDebugSymbols], false);
-  expect(
-    macosDefaultConfig[kFileOutput],
-    pathToServiceFile,
-  );
-}
-
 void checkAndroidFirebaseJsonValues(
   Map<String, dynamic> decodedFirebaseJson,
   List<String> keysToMapAndroid,
-  String pathToServiceFile,
-) {
+  String pathToServiceFile, {
+  String? appId = androidAppId,
+}) {
   final androidDefaultConfig =
       getNestedMap(decodedFirebaseJson, keysToMapAndroid);
-  expect(androidDefaultConfig[kAppId], androidAppId);
+  expect(androidDefaultConfig[kAppId], appId);
   expect(androidDefaultConfig[kProjectId], firebaseProjectId);
   expect(
     androidDefaultConfig[kFileOutput],
@@ -295,8 +295,11 @@ void checkAndroidFirebaseJsonValues(
 
 void checkDartFirebaseJsonValues(
   Map<String, dynamic> decodedFirebaseJson,
-  List<String> keysToMapDart,
-) {
+  List<String> keysToMapDart, {
+  String? appleAppId = appleAppId,
+  String? androidAppId = androidAppId,
+  String? webAppId = webAppId,
+}) {
   final dartConfig = getNestedMap(decodedFirebaseJson, keysToMapDart);
   expect(dartConfig[kProjectId], firebaseProjectId);
 

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -181,48 +181,39 @@ String? getValue(XmlElement dictionary, String key) {
 
 // TODO - we can update this for both apple platforms
 Future<void> testAppleServiceFileValues(
-  String iosPath,
-  String macosPath, {
+  String applePath,
+  // ios or macos
+   {
+  String platform = kIos,
   String? bundleId = appleBundleId,
   String? appId = appleAppId,
 }) async {
-  // Need to find mac file like this for it to work on CI. No idea why.
-  final macFile = await findFileInDirectory(macosPath, appleServiceFileName);
+  File? appleFile;
+  if (platform == kMacos) {
+    // Need to find mac file like this for it to work on CI. No idea why.
+    appleFile = await findFileInDirectory(applePath, appleServiceFileName);
+  } else {
+    appleFile = File(applePath);
+  }
 
-  final iosServiceFileContent = await File(iosPath).readAsString();
+  final appleServiceFileContent = await appleFile.readAsString();
 
-  final macosServiceFileContent = await macFile.readAsString();
 
-  final iosPlist = XmlDocument.parse(iosServiceFileContent);
-  final macosPlist = XmlDocument.parse(macosServiceFileContent);
+  final applePlist = XmlDocument.parse(appleServiceFileContent);
 
-  final iosDictionary = iosPlist.rootElement.findElements('dict').single;
+  final appleDictionary = applePlist.rootElement.findElements('dict').single;
 
-  final iosProjectId = getValue(iosDictionary, 'PROJECT_ID');
-  final iosBundleId = getValue(iosDictionary, 'BUNDLE_ID');
-  final iosGoogleAppId = getValue(iosDictionary, 'GOOGLE_APP_ID');
-  final iosApiKey = getValue(iosDictionary, 'API_KEY');
-  final iosGcmSenderId = getValue(iosDictionary, 'GCM_SENDER_ID');
+  final appleProjectId = getValue(appleDictionary, 'PROJECT_ID');
+  final appleBundleId = getValue(appleDictionary, 'BUNDLE_ID');
+  final appleGoogleAppId = getValue(appleDictionary, 'GOOGLE_APP_ID');
+  final appleApiKey = getValue(appleDictionary, 'API_KEY');
+  final appleGcmSenderId = getValue(appleDictionary, 'GCM_SENDER_ID');
 
-  expect(iosProjectId, firebaseProjectId);
-  expect(iosBundleId, bundleId);
-  expect(iosGoogleAppId, appId);
-  expect(iosApiKey, appleApiKey);
-  expect(iosGcmSenderId, appleGcmSenderId);
-
-  final macosDictionary = macosPlist.rootElement.findElements('dict').single;
-
-  final macosProjectId = getValue(macosDictionary, 'PROJECT_ID');
-  final macosBundleId = getValue(macosDictionary, 'BUNDLE_ID');
-  final macosGoogleAppId = getValue(macosDictionary, 'GOOGLE_APP_ID');
-  final macosApiKey = getValue(macosDictionary, 'API_KEY');
-  final macosGcmSenderId = getValue(macosDictionary, 'GCM_SENDER_ID');
-
-  expect(macosProjectId, firebaseProjectId);
-  expect(macosBundleId, bundleId);
-  expect(macosGoogleAppId, appId);
-  expect(macosApiKey, appleApiKey);
-  expect(macosGcmSenderId, appleGcmSenderId);
+  expect(appleProjectId, firebaseProjectId);
+  expect(appleBundleId, bundleId);
+  expect(appleGoogleAppId, appId);
+  expect(appleApiKey, appleApiKey);
+  expect(appleGcmSenderId, appleGcmSenderId);
 }
 
 void testAndroidServiceFileValues(

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -182,7 +182,7 @@ String? getValue(XmlElement dictionary, String key) {
 Future<void> testAppleServiceFileValues(
   String applePath,
   // ios or macos
-   {
+  {
   String platform = kIos,
   String? bundleId = appleBundleId,
   String? appId = appleAppId,
@@ -196,7 +196,6 @@ Future<void> testAppleServiceFileValues(
   }
 
   final appleServiceFileContent = await appleFile.readAsString();
-
 
   final applePlist = XmlDocument.parse(appleServiceFileContent);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Update includes:

1. Updated implementation so apple service files are always rewritten. 
2. Wrote an e2e test to prove service files and JSON files are rewritten if running "flutterfire configure" twice.
3. Refactored code for apple so we reuse functions.
4. Ensure dart config file rewrite doesn't prompt when passing `--yes` argument.

closes https://github.com/invertase/flutterfire_cli/issues/109

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
