### PR TITLE
fix: removing mendatory flag on bundle ids

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -63,7 +63,6 @@ class ConfigCommand extends FlutterFireCommand {
     argParser.addOption(
       kIosBundleIdFlag,
       valueHelp: 'bundleIdentifier',
-      mandatory: isCI,
       abbr: 'i',
       help: 'The bundle identifier of your iOS app, e.g. "com.example.app". '
           'If no identifier is provided then an attempt will be made to '
@@ -72,7 +71,6 @@ class ConfigCommand extends FlutterFireCommand {
     argParser.addOption(
       kMacosBundleIdFlag,
       valueHelp: 'bundleIdentifier',
-      mandatory: isCI,
       abbr: 'm',
       help: 'The bundle identifier of your macOS app, e.g. "com.example.app". '
           'If no identifier is provided then an attempt will be made to '
@@ -274,7 +272,15 @@ class ConfigCommand extends FlutterFireCommand {
   String? get iosBundleId {
     final value = argResults!['ios-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
-    return value;
+    if (value != null) return value;
+
+    if (isCI) {
+      throw FirebaseCommandException(
+        'configure',
+        'Please provide value for ios-bundle-id.',
+      );
+    }
+    return null;
   }
 
   String? get webAppId {
@@ -294,7 +300,15 @@ class ConfigCommand extends FlutterFireCommand {
   String? get macosBundleId {
     final value = argResults!['macos-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
-    return value;
+    if (value != null) return value;
+
+    if (isCI) {
+      throw FirebaseCommandException(
+        'configure',
+        'Please provide value for macos-bundle-id.',
+      );
+    }
+    return null;
   }
 
   String? get token {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Bundle IDs are flagged as mendatory when running inside a CI environment. This is causing #134, #100 .

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
