### PR TITLE
fix: if web not selected as platform, breaking `flutterfire configure` command

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,9 +16,6 @@
 
 include: all_lint_rules.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
   errors:
     # Otherwise cause the import of all_lint_rules to warn because of some rules conflicts.
     # We explicitly enabled even conflicting rules and are fixing the conflict

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -571,6 +571,7 @@ class ConfigCommand extends FlutterFireCommand {
       final firebaseJsonWrite = FirebaseDartConfigurationWrite(
         configurationFilePath:
             firebaseConfigurationFileInputs.configurationFilePath,
+        firebaseProjectId: selectedFirebaseProject.projectId,
         flutterAppPath: flutterApp!.package.path,
         androidOptions: fetchedFirebaseOptions.androidOptions,
         iosOptions: fetchedFirebaseOptions.iosOptions,

--- a/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
+++ b/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
@@ -293,6 +293,7 @@ class Reconfigure extends FlutterFireCommand {
       final future = Future(() async {
         return FirebaseDartConfigurationWrite(
           configurationFilePath: configWrite.pathToConfig,
+          firebaseProjectId: configWrite.projectId,
           flutterAppPath: flutterApp!.package.path,
           androidOptions: configWrite.androidOptions,
           iosOptions: configWrite.iosOptions,

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
@@ -25,6 +25,7 @@ class FirebaseDartConfigurationWrite {
   FirebaseDartConfigurationWrite({
     required this.configurationFilePath,
     required this.flutterAppPath,
+    required this.firebaseProjectId,
     this.androidOptions,
     this.iosOptions,
     this.macosOptions,
@@ -36,6 +37,7 @@ class FirebaseDartConfigurationWrite {
   final StringBuffer _stringBuffer = StringBuffer();
   final String configurationFilePath;
   final String flutterAppPath;
+  final String firebaseProjectId;
 
   FirebaseOptions? webOptions;
 
@@ -91,7 +93,7 @@ class FirebaseDartConfigurationWrite {
 
     return FirebaseJsonWrites(
       pathToMap: keysToMap,
-      projectId: webOptions!.projectId,
+      projectId: firebaseProjectId,
       configurations: configurations,
     );
   }

--- a/packages/flutterfire_cli/pubspec.yaml
+++ b/packages/flutterfire_cli/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   ansi_styles: ^0.3.2+1
   args: ^2.3.0
   ci: ^0.1.0
-  cli_util: ^0.3.5
-  deep_pick: ^0.10.0
+  cli_util: ^0.4.0
+  deep_pick: ^1.0.0
   file: ^6.1.2
   http: ^0.13.5
   interact: ^2.1.1
@@ -24,6 +24,6 @@ dependencies:
 
 dev_dependencies:
   googleapis_auth: ^1.4.0
-  test: ^1.16.0
+  test: ^1.24.3
 executables:
   flutterfire:

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -288,6 +288,10 @@ void checkDartFirebaseJsonValues(
   String? appleAppId = appleAppId,
   String? androidAppId = androidAppId,
   String? webAppId = webAppId,
+  bool checkIos = true,
+  bool checkMacos = true,
+  bool checkAndroid = true,
+  bool checkWeb = true,
 }) {
   final dartConfig = getNestedMap(decodedFirebaseJson, keysToMapDart);
   expect(dartConfig[kProjectId], firebaseProjectId);
@@ -295,8 +299,16 @@ void checkDartFirebaseJsonValues(
   final defaultConfigurations =
       dartConfig[kConfigurations] as Map<String, dynamic>;
 
-  expect(defaultConfigurations[kIos], appleAppId);
-  expect(defaultConfigurations[kMacos], appleAppId);
-  expect(defaultConfigurations[kAndroid], androidAppId);
-  expect(defaultConfigurations[kWeb], webAppId);
+  if (checkIos) {
+    expect(defaultConfigurations[kIos], appleAppId);
+  }
+  if (checkMacos) {
+    expect(defaultConfigurations[kMacos], appleAppId);
+  }
+  if (checkAndroid) {
+    expect(defaultConfigurations[kAndroid], androidAppId);
+  }
+  if (checkWeb) {
+    expect(defaultConfigurations[kWeb], webAppId);
+  }
 }

--- a/packages/flutterfire_starter/hooks/pre_gen.dart
+++ b/packages/flutterfire_starter/hooks/pre_gen.dart
@@ -17,7 +17,7 @@ Future<void> run(HookContext context) async {
 
 void _validatePluginList(HookContext context) {
   final varsPlugins =
-      ((context.vars['plugins'] as List<dynamic>).cast<String>())
+      (context.vars['plugins'] as List<dynamic>).cast<String>()
           .map((e) => e.split(' ')[0])
           .toList();
   final setPlugins = varsPlugins.toSet().toList();


### PR DESCRIPTION
## Description

This PR also updates dependencies which fixes this issue: https://github.com/invertase/flutterfire_cli/issues/181

closes https://github.com/invertase/flutterfire_cli/issues/181

This also fixes the `flutterfire configure` command when `web` is not a platform. E.g.
```bash
flutterfire configure --yes --project=dewqqqqkeww --platforms=ios,android --ios-build-config=Debug-development --ios-out=ios/config/dev/GoogleService-Info.plist --android-out=android/app/src/dev/google-services.json --overwrite-firebase-options --yes
```

I thought there was an issue for this but can't seem to find it now, maybe it was a comment somewhere.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
