### PR TITLE
fix: —out parameter now correctly changes the output file for the dar…

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -485,6 +485,7 @@ class ConfigCommand extends FlutterFireCommand {
     }
 
     final firebaseConfigurationFileInputs = dartConfigurationFileValidation(
+      configurationFilePath: outputFilePath,
       flutterAppPath: flutterApp!.package.path,
       overwrite: yes,
     );

--- a/packages/flutterfire_cli/lib/src/common/prompts/dart_file_prompts.dart
+++ b/packages/flutterfire_cli/lib/src/common/prompts/dart_file_prompts.dart
@@ -12,10 +12,14 @@ String getFirebaseConfigurationFile({
   final segments = removeForwardBackwardSlash(configurationFilePath).split('/');
 
   if (segments.last.contains('.dart')) {
-    return path.join(
-      flutterAppPath,
-      removeForwardBackwardSlash(configurationFilePath),
-    );
+    if (path.isAbsolute(configurationFilePath)) {
+      return configurationFilePath;
+    } else {
+      return path.join(
+        flutterAppPath,
+        removeForwardBackwardSlash(configurationFilePath),
+      );
+    }
   } else {
     final configurationFilePath = promptInput(
       'Enter a path for your FirebaseOptions file. It must be to a dart file. Example input: lib/firebase_options.dart',


### PR DESCRIPTION
…t firebase configuration

## Description

The --out parameter was not changing the output location of dart files. It seems this is a bug caused by recent changes as this has worked in the past.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
