### PR TITLE
Custom Xcode Project Name

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -62,6 +62,13 @@ class ConfigCommand extends FlutterFireCommand {
           'as a comma separated list. For example "android,ios,macos,web,linux,windows".',
     );
     argParser.addOption(
+      'ios-xc-project-name',
+      defaultsTo: 'Runner',
+      valueHelp: 'projectName',
+      mandatory: isCI,
+      help: 'The Xcode project name of your iOS app, e.g. "MyApp". ',
+    );
+    argParser.addOption(
       'ios-bundle-id',
       valueHelp: 'bundleIdentifier',
       mandatory: isCI,
@@ -69,6 +76,13 @@ class ConfigCommand extends FlutterFireCommand {
       help: 'The bundle identifier of your iOS app, e.g. "com.example.app". '
           'If no identifier is provided then an attempt will be made to '
           'automatically detect it from your "ios" folder (if it exists).',
+    );
+    argParser.addOption(
+      'macos-xc-project-name',
+      defaultsTo: 'Runner',
+      valueHelp: 'projectName',
+      mandatory: isCI,
+      help: 'The Xcode project name of your macOS app, e.g. "MyApp". ',
     );
     argParser.addOption(
       'macos-bundle-id',
@@ -205,6 +219,11 @@ class ConfigCommand extends FlutterFireCommand {
     return value;
   }
 
+  String get iosXcodeProjectName {
+    final value = argResults?['ios-xc-project-name'] as String?;
+    return value ?? 'Runner';
+  }
+
   String? get webAppId {
     final value = argResults!['web-app-id'] as String?;
 
@@ -223,6 +242,11 @@ class ConfigCommand extends FlutterFireCommand {
     final value = argResults!['macos-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
     return value;
+  }
+
+  String get macosXcodeProjectName {
+    final value = argResults!['macos-xc-project-name'] as String?;
+    return value ?? 'Runner';
   }
 
   String? get token {
@@ -407,6 +431,7 @@ class ConfigCommand extends FlutterFireCommand {
 
     FirebaseOptions? iosOptions;
     if (selectedPlatforms[kIos]!) {
+      flutterApp?.iosXcodeProjectName = iosXcodeProjectName;
       iosOptions = await FirebaseAppleOptions.forFlutterApp(
         flutterApp!,
         appleBundleIdentifier: iosBundleId,
@@ -418,6 +443,7 @@ class ConfigCommand extends FlutterFireCommand {
 
     FirebaseOptions? macosOptions;
     if (selectedPlatforms[kMacos]!) {
+      flutterApp?.macosXcodeProjectName = macosXcodeProjectName;
       macosOptions = await FirebaseAppleOptions.forFlutterApp(
         flutterApp!,
         appleBundleIdentifier: macosBundleId,
@@ -524,11 +550,11 @@ class ConfigCommand extends FlutterFireCommand {
         await file.writeAsString(iosOptions.optionsSourceContent);
       }
 
-      final xcodeProjFilePath =
-          path.join(flutterApp!.iosDirectory.path, 'Runner.xcodeproj');
+      final xcodeProjFilePath = path.join(
+          flutterApp!.iosDirectory.path, '$iosXcodeProjectName.xcodeproj');
 
-      final rubyScript =
-          generateRubyScript(googleServiceInfoFile, xcodeProjFilePath);
+      final rubyScript = generateRubyScript(
+          googleServiceInfoFile, xcodeProjFilePath, iosXcodeProjectName);
 
       if (Platform.isMacOS) {
         final result = await Process.run('ruby', [
@@ -554,11 +580,11 @@ class ConfigCommand extends FlutterFireCommand {
         await file.writeAsString(macosOptions.optionsSourceContent);
       }
 
-      final xcodeProjFilePath =
-          path.join(flutterApp!.macosDirectory.path, 'Runner.xcodeproj');
+      final xcodeProjFilePath = path.join(
+          flutterApp!.macosDirectory.path, '$macosXcodeProjectName.xcodeproj');
 
-      final rubyScript =
-          generateRubyScript(googleServiceInfoFile, xcodeProjFilePath);
+      final rubyScript = generateRubyScript(
+          googleServiceInfoFile, xcodeProjFilePath, macosXcodeProjectName);
 
       if (Platform.isMacOS) {
         final result = await Process.run('ruby', [

--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -173,18 +173,20 @@ String androidAppBuildGradlePathForAppDirectory(Directory directory) {
   return joinAll([directory.path, 'android', 'app', 'build.gradle']);
 }
 
-File xcodeProjectFileInDirectory(Directory directory, String platform) {
+File xcodeProjectFileInDirectory(
+    Directory directory, String platform, String xcProjectName) {
   return File(
     joinAll(
-      [directory.path, platform, 'Runner.xcodeproj', 'project.pbxproj'],
+      [directory.path, platform, '$xcProjectName.xcodeproj', 'project.pbxproj'],
     ),
   );
 }
 
-File xcodeAppInfoConfigFileInDirectory(Directory directory, String platform) {
+File xcodeAppInfoConfigFileInDirectory(
+    Directory directory, String platform, String xcProjectName) {
   return File(
     joinAll(
-      [directory.path, platform, 'Runner', 'Configs', 'AppInfo.xcconfig'],
+      [directory.path, platform, xcProjectName, 'Configs', 'AppInfo.xcconfig'],
     ),
   );
 }
@@ -212,11 +214,13 @@ String relativePath(String path, String from) {
 String generateRubyScript(
   String googleServiceInfoFile,
   String xcodeProjFilePath,
+  String xcodeProjectName,
 ) {
   return '''
 require 'xcodeproj'
 googleFile='$googleServiceInfoFile'
 xcodeFile='$xcodeProjFilePath'
+xcodeProjectName='$xcodeProjectName'
 
 # define the path to your .xcodeproj file
 project_path = xcodeFile
@@ -235,14 +239,14 @@ end
 # Write only if config doesn't exist
 if googleConfigExists == false
   file = project.new_file(googleFile)
-  main_target = project.targets.find { |target| target.name == 'Runner' }
+  main_target = project.targets.find { |target| target.name == xcodeProjectName }
   
   if(main_target)
     main_target.add_resources([file])
     project.save
   else
-    abort("Could not find target 'Runner' in your Xcode workspace. Please rename your target to 'Runner' and try again.")
-  end  
+      abort("Could not find target '$xcodeProjectName' in your Xcode workspace. Please rename your target to '$xcodeProjectName' and try again.")
+    end  
 end
 ''';
 }

--- a/packages/flutterfire_cli/lib/src/flutter_app.dart
+++ b/packages/flutterfire_cli/lib/src/flutter_app.dart
@@ -48,6 +48,17 @@ class FlutterApp {
   // Cached Android package name if available.
   String? _androidApplicationId;
 
+  // ios Xcode package name. Default 'Runner'
+  String? _iosXcodeProjectName;
+
+  String get iosXcodeProjectName {
+    return _iosXcodeProjectName ?? 'Runner';
+  }
+
+  set iosXcodeProjectName(String name) {
+    _iosXcodeProjectName = name;
+  }
+
   // Cached iOS bundle identifier if available.
   String? _iosBundleId;
 
@@ -56,7 +67,19 @@ class FlutterApp {
     if (_iosBundleId != null) {
       return _iosBundleId;
     }
-    return _iosBundleId = _readBundleIdForPlatform(kIos);
+
+    return _iosBundleId = _readBundleIdForPlatform(kIos, iosXcodeProjectName);
+  }
+
+  // ios Xcode package name. Default 'Runner'
+  String? _macosXcodeProjectName;
+
+  String get macosXcodeProjectName {
+    return _macosXcodeProjectName ?? 'Runner';
+  }
+
+  set macosXcodeProjectName(String name) {
+    _macosXcodeProjectName = name;
   }
 
   // Cached macOS bundle identifier if available.
@@ -67,20 +90,18 @@ class FlutterApp {
     if (_macosBundleId != null) {
       return _macosBundleId;
     }
-    return _macosBundleId = _readBundleIdForPlatform(kMacos);
+    return _macosBundleId = _readBundleIdForPlatform(kMacos, macosXcodeProjectName);
   }
 
-  String? _readBundleIdForPlatform(String platform) {
-    final xcodeProjFile =
-        xcodeProjectFileInDirectory(Directory(package.path), platform);
-    final xcodeAppInfoConfigFile =
-        xcodeAppInfoConfigFileInDirectory(Directory(package.path), platform);
+  String? _readBundleIdForPlatform(String platform, String xCodeProjectName) {
+    final xcodeProjFile = xcodeProjectFileInDirectory(Directory(package.path), platform, xCodeProjectName);
+    final xcodeAppInfoConfigFile = xcodeAppInfoConfigFileInDirectory(Directory(package.path), platform, xCodeProjectName);
     final bundleIdRegex = RegExp(
       r'''^[\s]*PRODUCT_BUNDLE_IDENTIFIER\s=\s(?<bundleId>[A-Za-z\d_\-\.]+)[;]*$''',
       multiLine: true,
     );
 
-    if (xcodeProjFile.existsSync()) {
+    if (xcodeProjFile.existsSync() && platform == kIos) {
       final fileContents = xcodeProjFile.readAsStringSync();
       // TODO there can be multiple matches, e.g. build variants,
       //      perhaps we should build a set and prompt for a choice?
@@ -155,8 +176,7 @@ class FlutterApp {
 
   /// Returns whether the package depends on the given package.
   bool dependsOnPackage(String packageName) {
-    return package.dependencies.contains(packageName) ||
-        package.devDependencies.contains(packageName);
+    return package.dependencies.contains(packageName) || package.devDependencies.contains(packageName);
   }
 
   /// Returns whether this Flutter app can run on Android.
@@ -227,12 +247,7 @@ class FlutterApp {
 
   Directory _platformDirectory(String platform) {
     assert(
-      platform == kIos ||
-          platform == kAndroid ||
-          platform == kWeb ||
-          platform == kMacos ||
-          platform == kWindows ||
-          platform == kLinux,
+      platform == kIos || platform == kAndroid || platform == kWeb || platform == kMacos || platform == kWindows || platform == kLinux,
     );
     return Directory(
       '${package.path}${currentPlatform.pathSeparator}$platform',


### PR DESCRIPTION
## Description

Added two new arguments for configuration.

`--ios-xc-project-name`
`--macos-ox-project-name`

When setting these args, the bundle identifier detection and configuration file creation work correctly.

**Related Issues**
#204 
#182 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [x] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
