### PR TITLE
fix: macOS bundleId was incorrectly selecting `some.app.RunnerTests`

### DIFF
--- a/packages/flutterfire_cli/lib/src/flutter_app.dart
+++ b/packages/flutterfire_cli/lib/src/flutter_app.dart
@@ -80,8 +80,11 @@ class FlutterApp {
       multiLine: true,
     );
 
-    if (xcodeProjFile.existsSync()) {
-      final fileContents = xcodeProjFile.readAsStringSync();
+    // Check AppInfo.xcconfig file first. It doesn't exist for iOS, but macOS has it with correct value.
+    // macOS project.pbxproj file contains incorrect PRODUCT_BUNDLE_IDENTIFIER value (e.g. some.project.RunnerTests).
+    // iOS will skip this check and will use project.pbxproj file.
+    if (xcodeAppInfoConfigFile.existsSync()) {
+      final fileContents = xcodeAppInfoConfigFile.readAsStringSync();
       // TODO there can be multiple matches, e.g. build variants,
       //      perhaps we should build a set and prompt for a choice?
       final match = bundleIdRegex.firstMatch(fileContents);
@@ -90,8 +93,8 @@ class FlutterApp {
       }
     }
 
-    if (xcodeAppInfoConfigFile.existsSync()) {
-      final fileContents = xcodeAppInfoConfigFile.readAsStringSync();
+    if (xcodeProjFile.existsSync()) {
+      final fileContents = xcodeProjFile.readAsStringSync();
       // TODO there can be multiple matches, e.g. build variants,
       //      perhaps we should build a set and prompt for a choice?
       final match = bundleIdRegex.firstMatch(fileContents);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Moved the file checks for bundleId so that `AppInfo.xcconfig` file is checked first. This file is present on macOS, not iOS. macOS `project.pbxproj` file contains incorrect bundle ID. It looks like the following for each build variation for Flutter apps created with the latest Flutter SDK:

```
PRODUCT_BUNDLE_IDENTIFIER = com.example.cliFlutterLatest.RunnerTests;
```

Logs from running `flutterfire configure` with this latest change:
```bash
➜  cli_flutter_latest git:(main) ✗ flutterfire configure --project=some-proj --yes
Building package executable... (1.7s)
Built flutterfire_cli_monorepo:flutterfire_dev.
i Found 20 Firebase projects. Selecting project some-proj.                                                                                                                                
i Selected platforms: android,ios,macos,web
i Firebase android app com.example.cli_flutter_latest registered.                                                                                                                           
i Firebase ios app com.example.cliFlutterLatest registered.                                                                                                                                 
i Firebase macos app com.example.cliFlutterLatest registered.                                                                                                                               
i Firebase web app cli_flutter_latest (web) registered.                                                                                                                                     

Firebase configuration file lib/firebase_options.dart generated successfully with the following Firebase apps:

Platform  Firebase App Id
web       1:361461320736:web:cd8dc12dc65cfa1c6f8045
android   1:361461320736:android:b128c52ad7fbb8656f8045
ios       1:361461320736:ios:889fe0536426efaf6f8045
macos     1:361461320736:ios:889fe0536426efaf6f8045

Learn more about using this file and next steps from the documentation:
 > https://firebase.google.com/docs/flutter/setup
```

fixes https://github.com/invertase/flutterfire_cli/issues/182

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
