### PR TITLE
feat: `flutterfire reconfigure` now updates android `build.gradle` files & Apple `project.pbxproj` for debug symbol script like `flutterfire configure`

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -552,6 +552,7 @@ class ConfigCommand extends FlutterFireCommand {
 
         if (reuseFirebaseJsonValues) {
           final reconfigure = Reconfigure(flutterApp, token: testAccessToken);
+          reconfigure.logger = logger;
           await reconfigure.run();
           return true;
         }

--- a/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
+++ b/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
@@ -25,7 +25,9 @@ import '../common/utils.dart';
 
 import '../firebase.dart';
 import '../firebase/firebase_android_options.dart';
+import '../firebase/firebase_android_writes.dart';
 import '../firebase/firebase_apple_options.dart';
+import '../firebase/firebase_apple_writes.dart';
 import '../firebase/firebase_dart_configuration_write.dart';
 import '../firebase/firebase_dart_options.dart';
 import '../firebase/firebase_options.dart';
@@ -133,6 +135,13 @@ class Reconfigure extends FlutterFireCommand {
     );
 
     if (buildConfigurationsExist) {
+      await addFlutterFireDebugSymbolsScript(
+        flutterAppPath: flutterApp!.package.path,
+        platform: platform,
+        logger: logger,
+        projectConfiguration: ProjectConfiguration.buildConfiguration,
+      );
+
       final buildConfigurations = getNestedMap(
         firebaseJsonMap,
         buildConfigurationKeys,
@@ -166,6 +175,13 @@ class Reconfigure extends FlutterFireCommand {
     );
 
     if (defaultConfigurationExists) {
+      await addFlutterFireDebugSymbolsScript(
+        flutterAppPath: flutterApp!.package.path,
+        platform: platform,
+        logger: logger,
+        projectConfiguration: ProjectConfiguration.defaultConfig,
+      );
+
       await _writeFile(
         _updateServiceFile(
           getNestedMap(
@@ -192,6 +208,13 @@ class Reconfigure extends FlutterFireCommand {
 
       final futures = <Future<void>>[];
       targets.forEach((key, dynamic value) async {
+        await addFlutterFireDebugSymbolsScript(
+          target: key,
+          flutterAppPath: flutterApp!.package.path,
+          platform: platform,
+          logger: logger,
+          projectConfiguration: ProjectConfiguration.target,
+        );
         // ignore: cast_nullable_to_non_nullable
         final configuration = targets[key] as Map<String, dynamic>;
         futures.add(
@@ -353,6 +376,8 @@ class Reconfigure extends FlutterFireCommand {
       final buildConfigurationKeys = [...androidKeys, kBuildConfiguration];
       final androidBuildConfigurationsExist =
           doesNestedMapExist(firebaseJsonMap, buildConfigurationKeys);
+
+      await gradleContentUpdates(flutterApp!);
 
       if (androidBuildConfigurationsExist) {
         final buildConfigurations =

--- a/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
+++ b/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
@@ -18,6 +18,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cli_util/cli_logging.dart';
 import 'package:path/path.dart' as path;
 
 import '../common/strings.dart';
@@ -73,6 +74,7 @@ class Reconfigure extends FlutterFireCommand {
   final String name = 'reconfigure';
 
   String? _accessToken;
+  late Logger _logger;
 
   String? get accessToken {
     // If we call reconfigure from `flutterfire configure`, `argResults` will be null and throw exception
@@ -85,6 +87,18 @@ class Reconfigure extends FlutterFireCommand {
 
   set accessToken(String? value) {
     _accessToken = value;
+  }
+
+  // Necessary as we don't have access to the logger when we run this command from `flutterfire configure`
+  @override
+  Logger get logger => globalResults != null
+      ? globalResults!['verbose'] as bool
+          ? Logger.verbose()
+          : Logger.standard()
+      : _logger;
+
+  set logger(Logger value) {
+    _logger = value;
   }
 
   Future<void> _updateServiceFile(

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -52,6 +52,16 @@ const _performancePluginClass = 'com.google.firebase.firebase-perf';
 const _flutterFireConfigCommentStart = '// START: FlutterFire Configuration';
 const _flutterFireConfigCommentEnd = '// END: FlutterFire Configuration';
 
+class AndroidGradleContents {
+  AndroidGradleContents({
+    required this.buildGradleContent,
+    required this.appBuildGradleContent,
+  });
+
+  final String buildGradleContent;
+  final String appBuildGradleContent;
+}
+
 class FirebaseAndroidWrites {
   FirebaseAndroidWrites({
     required this.flutterApp,
@@ -90,7 +100,7 @@ class FirebaseAndroidWrites {
     }
   }
 
-  Future<void> createAndroidGoogleServicesJsonFile() async {
+  Future<void> _writeAndroidGoogleServicesJsonFile() async {
     if (projectConfiguration == ProjectConfiguration.buildConfiguration) {
       final updatedPath = path.join(
         flutterApp.package.path,
@@ -98,6 +108,10 @@ class FirebaseAndroidWrites {
       );
       await File(updatedPath).create(recursive: true);
     }
+
+    await androidGoogleServicesJsonFile.writeAsString(
+      firebaseOptions.optionsSourceContent,
+    );
   }
 
   FirebaseJsonWrites _firebaseJsonWrites() {
@@ -134,167 +148,235 @@ class FirebaseAndroidWrites {
     );
   }
 
-  File get androidBuildGradleFile =>
-      File(path.join(flutterApp.androidDirectory.path, 'build.gradle'));
-  String? _androidBuildGradleFileContents;
-  set androidBuildGradleFileContents(String contents) =>
-      _androidBuildGradleFileContents = contents;
-  String get androidBuildGradleFileContents =>
-      _androidBuildGradleFileContents ??=
-          androidBuildGradleFile.readAsStringSync();
-
-  File get androidAppBuildGradleFile =>
-      File(path.join(flutterApp.androidDirectory.path, 'app', 'build.gradle'));
-  String? _androidAppBuildGradleFileContents;
-  set androidAppBuildGradleFileContents(String contents) =>
-      _androidAppBuildGradleFileContents = contents;
-  String get androidAppBuildGradleFileContents =>
-      _androidAppBuildGradleFileContents ??=
-          androidAppBuildGradleFile.readAsStringSync();
-
-  Future<void> applyGoogleServicesPlugin() async {
-    await createAndroidGoogleServicesJsonFile();
-
-    await androidGoogleServicesJsonFile.writeAsString(
-      firebaseOptions.optionsSourceContent,
-    );
-
-    if (!androidBuildGradleFileContents.contains(_googleServicesPluginClass)) {
-      final hasMatch =
-          _androidBuildGradleRegex.hasMatch(androidBuildGradleFileContents);
-      if (!hasMatch) {
-        // TODO some unrecoverable error here
-        return;
-      }
-    } else {
-      // TODO already contains google services, should we upgrade version?
-      return;
-    }
-    androidBuildGradleFileContents = androidBuildGradleFileContents
-        .replaceFirstMapped(_androidBuildGradleRegex, (match) {
-      final indentation = match.group(1);
-      return '${match.group(0)}\n$indentation$_flutterFireConfigCommentStart\n$indentation$_googleServicesPlugin\n$indentation$_flutterFireConfigCommentEnd';
-    });
-
-    if (!androidAppBuildGradleFileContents
-        .contains(_googleServicesPluginClass)) {
-      final hasMatch = _androidAppBuildGradleRegex
-          .hasMatch(androidAppBuildGradleFileContents);
-      if (!hasMatch) {
-        // TODO some unrecoverable error here?
-        return;
-      }
-    } else {
-      // Already applied.
-      return;
-    }
-
-    androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
-        .replaceFirstMapped(_androidAppBuildGradleRegex, (match) {
-      // Check which pattern was matched and insert the appropriate content
-      if (match.group(0) != null) {
-        if (match.group(0)!.trim().startsWith('id')) {
-          // If matched pattern is 'id "com.android.application"'
-          return "${match.group(0)}\n    $_flutterFireConfigCommentStart\n    id '$_googleServicesPluginName'\n    $_flutterFireConfigCommentEnd";
-        } else {
-          // If matched pattern is 'apply plugin:...'
-          return "${match.group(0)}\n$_flutterFireConfigCommentStart\napply plugin: '$_googleServicesPluginName'\n$_flutterFireConfigCommentEnd";
-        }
-      }
-      throw Exception(
-        'Could not match pattern in android/app `build.gradle` file for plugin $_googleServicesPluginName',
-      );
-    });
-  }
-
-  void _applyFirebaseAndroidPlugin({
-    required String pluginClassPath,
-    required String pluginClassPathVersion,
-    required String pluginClass,
-  }) {
-    if (!androidBuildGradleFileContents.contains(pluginClassPath)) {
-      final hasMatch = _androidBuildGradleGoogleServicesRegex
-          .hasMatch(androidBuildGradleFileContents);
-      if (!hasMatch) {
-        // TODO some unrecoverable error here
-        return;
-      }
-    } else {
-      // TODO already contains plugin, should we upgrade version?
-      return;
-    }
-    androidBuildGradleFileContents = androidBuildGradleFileContents
-        .replaceFirstMapped(_androidBuildGradleGoogleServicesRegex, (match) {
-      final indentation = match.group(2);
-      return "${match.group(1)}\n${indentation}classpath '$pluginClassPath:$pluginClassPathVersion'";
-    });
-
-    if (!androidAppBuildGradleFileContents.contains(pluginClass)) {
-      final hasMatch = _androidAppBuildGradleGoogleServicesRegex
-          .hasMatch(androidAppBuildGradleFileContents);
-      if (!hasMatch) {
-        // TODO some unrecoverable error here?
-        return;
-      }
-    } else {
-      // Already applied.
-      return;
-    }
-    androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
-        .replaceFirstMapped(_androidAppBuildGradleGoogleServicesRegex, (match) {
-      // Check which pattern was matched and insert the appropriate content
-      if (match.group(0) != null) {
-        if (match.group(0)!.trim().startsWith('id')) {
-          // If matched pattern is 'id "com.google.gms.google-services"'
-          return "${match.group(0)}\n    id '$pluginClass'";
-        } else {
-          // If matched pattern is 'apply plugin:...'
-          return "${match.group(0)}\napply plugin: '$pluginClass'";
-        }
-      }
-      throw Exception(
-        'Could not match pattern in android/app `build.gradle` file for plugin $pluginClass',
-      );
-    });
-  }
-
-  Future<void> applyCrashlyticsPlugin() async {
-    if (!flutterApp.dependsOnPackage('firebase_crashlytics')) {
-      // Skip since user doesn't have the plugin installed.
-      return;
-    }
-    _applyFirebaseAndroidPlugin(
-      pluginClassPath: _crashlyticsPluginClassPath,
-      pluginClassPathVersion: _crashlyticsPluginClassPathVersion,
-      pluginClass: _crashlyticsPluginClass,
-    );
-  }
-
-  Future<void> applyPerformancePlugin() async {
-    if (!flutterApp.dependsOnPackage('firebase_performance')) {
-      // Skip since user doesn't have the plugin installed.
-      return;
-    }
-    _applyFirebaseAndroidPlugin(
-      pluginClassPath: _performancePluginClassPath,
-      pluginClassPathVersion: _performancePluginClassPathVersion,
-      pluginClass: _performancePluginClass,
-    );
-  }
-
   Future<FirebaseJsonWrites> apply() async {
-    await applyGoogleServicesPlugin();
-    await applyCrashlyticsPlugin();
-    await applyPerformancePlugin();
+    await _writeAndroidGoogleServicesJsonFile();
 
-    // WRITE <app>/android/build.gradle
-    await androidBuildGradleFile.writeAsString(androidBuildGradleFileContents);
-
-    // WRITE <app>/android/app/build.gradle
-    await androidAppBuildGradleFile.writeAsString(
-      androidAppBuildGradleFileContents,
-    );
+    await gradleContentUpdates(flutterApp);
 
     return _firebaseJsonWrites();
   }
+}
+
+Future<void> gradleContentUpdates(
+  FlutterApp flutterApp,
+) async {
+  final androidBuildGradleFile = File(
+    path.join(
+      flutterApp.androidDirectory.path,
+      'build.gradle',
+    ),
+  );
+  final androidBuildGradleFileContents =
+      androidBuildGradleFile.readAsStringSync();
+
+  final androidAppBuildGradleFile = File(
+    path.join(
+      flutterApp.androidDirectory.path,
+      'app',
+      'build.gradle',
+    ),
+  );
+  final androidAppBuildGradleFileContents =
+      androidAppBuildGradleFile.readAsStringSync();
+
+  var content = AndroidGradleContents(
+    buildGradleContent: androidBuildGradleFileContents,
+    appBuildGradleContent: androidAppBuildGradleFileContents,
+  );
+
+  content = _applyGoogleServicesPlugin(
+    flutterApp,
+    content,
+  );
+
+  if (flutterApp.dependsOnPackage('firebase_crashlytics')) {
+    // Apply only if firebase_crashlytics is present
+    content = _applyCrashlyticsPlugin(
+      flutterApp,
+      content,
+    );
+  }
+
+  if (flutterApp.dependsOnPackage('firebase_performance')) {
+    // Apply only if firebase_performance is present
+    content = _applyPerformancePlugin(
+      flutterApp,
+      content,
+    );
+  }
+
+  // WRITE <app>/android/build.gradle
+  await androidBuildGradleFile.writeAsString(content.buildGradleContent);
+
+  // WRITE <app>/android/app/build.gradle
+  await androidAppBuildGradleFile.writeAsString(
+    content.appBuildGradleContent,
+  );
+}
+
+AndroidGradleContents _applyGoogleServicesPlugin(
+  FlutterApp flutterApp,
+  AndroidGradleContents content,
+) {
+  var androidBuildGradleFileContents = content.buildGradleContent;
+  var androidAppBuildGradleFileContents = content.appBuildGradleContent;
+
+  if (!androidBuildGradleFileContents.contains(_googleServicesPluginClass)) {
+    final hasMatch =
+        _androidBuildGradleRegex.hasMatch(androidBuildGradleFileContents);
+    if (!hasMatch) {
+      // TODO some unrecoverable error here
+      return AndroidGradleContents(
+        buildGradleContent: androidBuildGradleFileContents,
+        appBuildGradleContent: androidAppBuildGradleFileContents,
+      );
+    }
+  } else {
+    // TODO already contains google services, should we upgrade version?
+    return AndroidGradleContents(
+      buildGradleContent: androidBuildGradleFileContents,
+      appBuildGradleContent: androidAppBuildGradleFileContents,
+    );
+  }
+  androidBuildGradleFileContents = androidBuildGradleFileContents
+      .replaceFirstMapped(_androidBuildGradleRegex, (match) {
+    final indentation = match.group(1);
+    return '${match.group(0)}\n$indentation$_flutterFireConfigCommentStart\n$indentation$_googleServicesPlugin\n$indentation$_flutterFireConfigCommentEnd';
+  });
+
+  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginClass)) {
+    final hasMatch =
+        _androidAppBuildGradleRegex.hasMatch(androidAppBuildGradleFileContents);
+    if (!hasMatch) {
+      // TODO some unrecoverable error here?
+      return AndroidGradleContents(
+        buildGradleContent: androidBuildGradleFileContents,
+        appBuildGradleContent: androidAppBuildGradleFileContents,
+      );
+    }
+  } else {
+    // Already applied.
+    return AndroidGradleContents(
+      buildGradleContent: androidBuildGradleFileContents,
+      appBuildGradleContent: androidAppBuildGradleFileContents,
+    );
+  }
+
+  androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
+      .replaceFirstMapped(_androidAppBuildGradleRegex, (match) {
+    // Check which pattern was matched and insert the appropriate content
+    if (match.group(0) != null) {
+      if (match.group(0)!.trim().startsWith('id')) {
+        // If matched pattern is 'id "com.android.application"'
+        return "${match.group(0)}\n    $_flutterFireConfigCommentStart\n    id '$_googleServicesPluginName'\n    $_flutterFireConfigCommentEnd";
+      } else {
+        // If matched pattern is 'apply plugin:...'
+        return "${match.group(0)}\n$_flutterFireConfigCommentStart\napply plugin: '$_googleServicesPluginName'\n$_flutterFireConfigCommentEnd";
+      }
+    }
+    throw Exception(
+      'Could not match pattern in android/app `build.gradle` file for plugin $_googleServicesPluginName',
+    );
+  });
+
+  return AndroidGradleContents(
+    buildGradleContent: androidBuildGradleFileContents,
+    appBuildGradleContent: androidAppBuildGradleFileContents,
+  );
+}
+
+AndroidGradleContents _applyCrashlyticsPlugin(
+  FlutterApp flutterApp,
+  AndroidGradleContents content,
+) {
+  return _applyFirebaseAndroidPlugin(
+    pluginClassPath: _crashlyticsPluginClassPath,
+    pluginClassPathVersion: _crashlyticsPluginClassPathVersion,
+    pluginClass: _crashlyticsPluginClass,
+    content: content,
+  );
+}
+
+AndroidGradleContents _applyPerformancePlugin(
+  FlutterApp flutterApp,
+  AndroidGradleContents content,
+) {
+  return _applyFirebaseAndroidPlugin(
+    pluginClassPath: _performancePluginClassPath,
+    pluginClassPathVersion: _performancePluginClassPathVersion,
+    pluginClass: _performancePluginClass,
+    content: content,
+  );
+}
+
+AndroidGradleContents _applyFirebaseAndroidPlugin({
+  required String pluginClassPath,
+  required String pluginClassPathVersion,
+  required String pluginClass,
+  required AndroidGradleContents content,
+}) {
+  var androidBuildGradleFileContents = content.buildGradleContent;
+  var androidAppBuildGradleFileContents = content.appBuildGradleContent;
+
+  if (!androidBuildGradleFileContents.contains(pluginClassPath)) {
+    final hasMatch = _androidBuildGradleGoogleServicesRegex
+        .hasMatch(androidBuildGradleFileContents);
+    if (!hasMatch) {
+      // TODO some unrecoverable error here
+      return AndroidGradleContents(
+        buildGradleContent: androidBuildGradleFileContents,
+        appBuildGradleContent: androidAppBuildGradleFileContents,
+      );
+    }
+  } else {
+    // TODO already contains plugin, should we upgrade version?
+    return AndroidGradleContents(
+      buildGradleContent: androidBuildGradleFileContents,
+      appBuildGradleContent: androidAppBuildGradleFileContents,
+    );
+  }
+  androidBuildGradleFileContents = androidBuildGradleFileContents
+      .replaceFirstMapped(_androidBuildGradleGoogleServicesRegex, (match) {
+    final indentation = match.group(2);
+    return "${match.group(1)}\n${indentation}classpath '$pluginClassPath:$pluginClassPathVersion'";
+  });
+
+  if (!androidAppBuildGradleFileContents.contains(pluginClass)) {
+    final hasMatch = _androidAppBuildGradleGoogleServicesRegex
+        .hasMatch(androidAppBuildGradleFileContents);
+    if (!hasMatch) {
+      // TODO some unrecoverable error here?
+      return AndroidGradleContents(
+        buildGradleContent: androidBuildGradleFileContents,
+        appBuildGradleContent: androidAppBuildGradleFileContents,
+      );
+    }
+  } else {
+    // Already applied.
+    return AndroidGradleContents(
+      buildGradleContent: androidBuildGradleFileContents,
+      appBuildGradleContent: androidAppBuildGradleFileContents,
+    );
+  }
+  androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
+      .replaceFirstMapped(_androidAppBuildGradleGoogleServicesRegex, (match) {
+    // Check which pattern was matched and insert the appropriate content
+    if (match.group(0) != null) {
+      if (match.group(0)!.trim().startsWith('id')) {
+        // If matched pattern is 'id "com.google.gms.google-services"'
+        return "${match.group(0)}\n    id '$pluginClass'";
+      } else {
+        // If matched pattern is 'apply plugin:...'
+        return "${match.group(0)}\napply plugin: '$pluginClass'";
+      }
+    }
+    throw Exception(
+      'Could not match pattern in android/app `build.gradle` file for plugin $pluginClass',
+    );
+  });
+
+  return AndroidGradleContents(
+    buildGradleContent: androidBuildGradleFileContents,
+    appBuildGradleContent: androidAppBuildGradleFileContents,
+  );
 }

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -8,6 +8,11 @@ import 'package:yaml/yaml.dart';
 import '../common/utils.dart';
 import '../firebase/firebase_options.dart';
 
+const debugSymbolScriptName =
+    'FlutterFire: "flutterfire upload-crashlytics-symbols"';
+const bundleServiceScriptName =
+    'FlutterFire: "flutterfire bundle-service-file"';
+
 Future<FirebaseJsonWrites> appleWrites({
   required String platform,
   required String flutterAppPath,
@@ -117,8 +122,12 @@ end
     await _writeGoogleServiceFileToPath();
     await _writeGoogleServiceFileToTargetProject();
 
-    final debugSymbolScriptAdded = await _addFlutterFireDebugSymbolsScript(
+    final debugSymbolScriptAdded = await addFlutterFireDebugSymbolsScript(
       target: target,
+      flutterAppPath: flutterAppPath,
+      logger: logger,
+      platform: platform,
+      projectConfiguration: projectConfiguration,
     );
 
     return _firebaseJsonWrites(debugSymbolScriptAdded, target);
@@ -209,7 +218,12 @@ end
   Future<FirebaseJsonWrites> _buildConfigurationWrites() async {
     await _writeGoogleServiceFileToPath();
     await _writeBundleServiceFileScriptToProject();
-    final debugSymbolScriptAdded = await _addFlutterFireDebugSymbolsScript();
+    final debugSymbolScriptAdded = await addFlutterFireDebugSymbolsScript(
+      flutterAppPath: flutterAppPath,
+      logger: logger,
+      projectConfiguration: projectConfiguration,
+      platform: platform,
+    );
 
     return _firebaseJsonWrites(
       debugSymbolScriptAdded,
@@ -240,124 +254,6 @@ abstract class FirebaseAppleConfiguration {
   final String serviceFilePath;
   final Logger logger;
   ProjectConfiguration projectConfiguration;
-
-  Future<bool> _addFlutterFireDebugSymbolsScript({
-    String target = 'Runner',
-  }) async {
-    final packageConfigContents = File(
-      path.join(
-        flutterAppPath,
-        '.dart_tool',
-        'package_config.json',
-      ),
-    );
-
-    var crashlyticsDependencyExists = false;
-    const crashlyticsDependency = 'firebase_crashlytics';
-
-    if (packageConfigContents.existsSync()) {
-      final decodePackageConfig = await packageConfigContents.readAsString();
-
-      final packageConfig = jsonDecode(decodePackageConfig) as Map;
-
-      final packages = packageConfig['packages'] as List<dynamic>;
-      crashlyticsDependencyExists = packages.any(
-        (dynamic package) =>
-            package is Map && package['name'] == crashlyticsDependency,
-      );
-    } else {
-      final pubspecContents = await File(
-        path.join(
-          flutterAppPath,
-          'pubspec.yaml',
-        ),
-      ).readAsString();
-
-      final yamlContents = loadYaml(pubspecContents) as Map;
-
-      crashlyticsDependencyExists = yamlContents['dependencies'] != null &&
-          (yamlContents['dependencies'] as Map)
-              .containsKey(crashlyticsDependency);
-    }
-
-    if (crashlyticsDependencyExists) {
-      // Add the debug script
-
-      final debugSymbolScript = await Process.run('ruby', [
-        '-e',
-        _debugSymbolsScript(
-          target,
-        ),
-      ]);
-
-      if (debugSymbolScript.exitCode != 0) {
-        throw Exception(debugSymbolScript.stderr);
-      }
-
-      if (debugSymbolScript.stdout != null) {
-        logger.stdout(debugSymbolScript.stdout as String);
-      }
-      return true;
-    }
-    return false;
-  }
-
-  String _debugSymbolsScript(
-    // Always "Runner" for "build configuration" setup
-    String target,
-  ) {
-    var command =
-        'flutterfire upload-crashlytics-symbols --upload-symbols-script-path=\$PODS_ROOT/FirebaseCrashlytics/upload-symbols --debug-symbols-path=\${DWARF_DSYM_FOLDER_PATH}/\${DWARF_DSYM_FILE_NAME} --info-plist-path=\${SRCROOT}/\${BUILT_PRODUCTS_DIR}/\${INFOPLIST_PATH} --platform=$platform --apple-project-path=\${SRCROOT} ';
-
-    switch (projectConfiguration) {
-      case ProjectConfiguration.buildConfiguration:
-        command += r'--build-configuration=${CONFIGURATION}';
-        break;
-      case ProjectConfiguration.target:
-        command += '--target=$target';
-        break;
-      case ProjectConfiguration.defaultConfig:
-        command += '--default-config=default';
-    }
-
-    return '''
-require 'xcodeproj'
-xcodeFile='${getXcodeProjectPath(platform)}'
-runScriptName='$debugSymbolScriptName'
-project = Xcodeproj::Project.open(xcodeFile)
-
-
-# multi line argument for bash script
-bashScript = %q(
-#!/bin/bash
-PATH=\${PATH}:\$FLUTTER_ROOT/bin:\$HOME/.pub-cache/bin
-$command
-)
-
-for target in project.targets 
-  if (target.name == '$target')
-    phase = target.shell_script_build_phases().find do |item|
-      if defined? item && item.name
-        item.name == runScriptName
-      end
-    end
-
-    if (!phase.nil?)
-      phase.remove_from_project()
-    end
-    
-    phase = target.new_shell_script_build_phase(runScriptName)
-    phase.shell_script = bashScript
-    project.save()   
-  end  
-end
-''';
-  }
-
-  final debugSymbolScriptName =
-      'FlutterFire: "flutterfire upload-crashlytics-symbols"';
-  final bundleServiceScriptName =
-      'FlutterFire: "flutterfire bundle-service-file"';
 
   FirebaseJsonWrites _firebaseJsonWrites(
     bool uploadDebugSymbols,
@@ -395,4 +291,125 @@ end
   }
 
   Future<FirebaseJsonWrites> apply();
+}
+
+Future<bool> addFlutterFireDebugSymbolsScript({
+  String target = 'Runner',
+  required String flutterAppPath,
+  required Logger logger,
+  required String platform,
+  required ProjectConfiguration projectConfiguration,
+}) async {
+  final packageConfigContents = File(
+    path.join(
+      flutterAppPath,
+      '.dart_tool',
+      'package_config.json',
+    ),
+  );
+
+  var crashlyticsDependencyExists = false;
+  const crashlyticsDependency = 'firebase_crashlytics';
+
+  if (packageConfigContents.existsSync()) {
+    final decodePackageConfig = await packageConfigContents.readAsString();
+
+    final packageConfig = jsonDecode(decodePackageConfig) as Map;
+
+    final packages = packageConfig['packages'] as List<dynamic>;
+    crashlyticsDependencyExists = packages.any(
+      (dynamic package) =>
+          package is Map && package['name'] == crashlyticsDependency,
+    );
+  } else {
+    final pubspecContents = await File(
+      path.join(
+        flutterAppPath,
+        'pubspec.yaml',
+      ),
+    ).readAsString();
+
+    final yamlContents = loadYaml(pubspecContents) as Map;
+
+    crashlyticsDependencyExists = yamlContents['dependencies'] != null &&
+        (yamlContents['dependencies'] as Map)
+            .containsKey(crashlyticsDependency);
+  }
+
+  if (crashlyticsDependencyExists) {
+    // Add the debug script
+
+    final debugSymbolScript = await Process.run('ruby', [
+      '-e',
+      _debugSymbolsScript(
+        target,
+        projectConfiguration,
+        platform,
+      ),
+    ]);
+
+    if (debugSymbolScript.exitCode != 0) {
+      throw Exception(debugSymbolScript.stderr);
+    }
+
+    if (debugSymbolScript.stdout != null) {
+      logger.stdout(debugSymbolScript.stdout as String);
+    }
+    return true;
+  }
+  return false;
+}
+
+String _debugSymbolsScript(
+  // Always "Runner" for "build configuration" setup
+  String target,
+  ProjectConfiguration projectConfiguration,
+  String platform,
+) {
+  var command =
+      'flutterfire upload-crashlytics-symbols --upload-symbols-script-path=\$PODS_ROOT/FirebaseCrashlytics/upload-symbols --debug-symbols-path=\${DWARF_DSYM_FOLDER_PATH}/\${DWARF_DSYM_FILE_NAME} --info-plist-path=\${SRCROOT}/\${BUILT_PRODUCTS_DIR}/\${INFOPLIST_PATH} --platform=$platform --apple-project-path=\${SRCROOT} ';
+
+  switch (projectConfiguration) {
+    case ProjectConfiguration.buildConfiguration:
+      command += r'--build-configuration=${CONFIGURATION}';
+      break;
+    case ProjectConfiguration.target:
+      command += '--target=$target';
+      break;
+    case ProjectConfiguration.defaultConfig:
+      command += '--default-config=default';
+  }
+
+  return '''
+require 'xcodeproj'
+xcodeFile='${getXcodeProjectPath(platform)}'
+runScriptName='$debugSymbolScriptName'
+project = Xcodeproj::Project.open(xcodeFile)
+
+
+# multi line argument for bash script
+bashScript = %q(
+#!/bin/bash
+PATH=\${PATH}:\$FLUTTER_ROOT/bin:\$HOME/.pub-cache/bin
+$command
+)
+
+for target in project.targets 
+  if (target.name == '$target')
+    phase = target.shell_script_build_phases().find do |item|
+      if defined? item && item.name
+        item.name == runScriptName
+      end
+    end
+
+    if (!phase.nil?)
+      phase.remove_from_project()
+    end
+    
+    phase = target.new_shell_script_build_phase(runScriptName)
+    phase.shell_script = bashScript
+    project.save()   
+  end  
+end
+''';
 }

--- a/packages/flutterfire_cli/test/reconfigure_test.dart
+++ b/packages/flutterfire_cli/test/reconfigure_test.dart
@@ -65,6 +65,21 @@ void main() {
         fail(result.stderr);
       }
 
+      final addDependencies = Process.runSync(
+        'flutter',
+        [
+          'pub',
+          'add',
+          'firebase_crashlytics',
+          'firebase_performance',
+        ],
+        workingDirectory: projectPath,
+      );
+
+      if (addDependencies.exitCode != 0) {
+        fail(addDependencies.stderr);
+      }
+
       String? iosPath;
       String? macosPath;
       if (Platform.isMacOS) {
@@ -81,6 +96,8 @@ void main() {
 
         await File(iosPath).delete();
         await macFile.delete();
+        // Clean up the project files to ensure the reconfigure command works
+        await cleanXcodeProjFiles(projectPath!);
       }
       final firebaseOptionsPath =
           p.join(projectPath!, 'lib', 'firebase_options.dart');
@@ -94,6 +111,9 @@ void main() {
       await File(androidServiceFilePath).delete();
 
       final accessToken = await generateAccessTokenCI();
+
+      // Clean up the project files to ensure the reconfigure command works
+      await cleanBuildGradleFiles(projectPath!);
 
       final result2 = Process.runSync(
         'flutterfire',
@@ -110,6 +130,11 @@ void main() {
 
       testAndroidServiceFileValues(androidServiceFilePath);
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
+      await checkBuildGradleFileUpdated(
+        projectPath!,
+        checkCrashlytics: true,
+        checkPerf: true,
+      );
 
       if (Platform.isMacOS) {
         await testAppleServiceFileValues(iosPath!);
@@ -117,6 +142,7 @@ void main() {
           macosPath!,
           platform: kMacos,
         );
+        await checkXcodeProjFiles(projectPath!);
       }
     },
     timeout: const Timeout(
@@ -155,6 +181,21 @@ void main() {
         fail(result.stderr);
       }
 
+      final addDependencies = Process.runSync(
+        'flutter',
+        [
+          'pub',
+          'add',
+          'firebase_crashlytics',
+          'firebase_performance',
+        ],
+        workingDirectory: projectPath,
+      );
+
+      if (addDependencies.exitCode != 0) {
+        fail(addDependencies.stderr);
+      }
+
       String? iosPath;
       String? macosPath;
       if (Platform.isMacOS) {
@@ -175,6 +216,8 @@ void main() {
 
         await File(iosPath).delete();
         await macFile.delete();
+        // Clean up the project files to ensure the reconfigure command works
+        await cleanXcodeProjFiles(projectPath!);
       }
       final firebaseOptionsPath =
           p.join(projectPath!, 'lib', 'firebase_options.dart');
@@ -188,6 +231,8 @@ void main() {
 
       await File(firebaseOptionsPath).delete();
       await File(androidServiceFilePath).delete();
+      // Clean up the project files to ensure the reconfigure command works
+      await cleanBuildGradleFiles(projectPath!);
 
       final accessToken = await generateAccessTokenCI();
 
@@ -206,6 +251,11 @@ void main() {
 
       testAndroidServiceFileValues(androidServiceFilePath);
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
+      await checkBuildGradleFileUpdated(
+        projectPath!,
+        checkCrashlytics: true,
+        checkPerf: true,
+      );
 
       if (Platform.isMacOS) {
         await testAppleServiceFileValues(iosPath!);
@@ -213,6 +263,7 @@ void main() {
           macosPath!,
           platform: kMacos,
         );
+        await checkXcodeProjFiles(projectPath!);
       }
     },
     timeout: const Timeout(
@@ -226,7 +277,7 @@ void main() {
       const targetType = 'Runner';
       const applePath = 'staging/target';
       const androidBuildConfiguration = 'development';
-      Process.runSync(
+      final result = Process.runSync(
         'flutterfire',
         [
           'configure',
@@ -250,6 +301,25 @@ void main() {
         workingDirectory: projectPath,
       );
 
+      if (result.exitCode != 0) {
+        fail(result.stderr);
+      }
+
+      final addDependencies = Process.runSync(
+        'flutter',
+        [
+          'pub',
+          'add',
+          'firebase_crashlytics',
+          'firebase_performance',
+        ],
+        workingDirectory: projectPath,
+      );
+
+      if (addDependencies.exitCode != 0) {
+        fail(addDependencies.stderr);
+      }
+
       String? iosPath;
       String? macosPath;
       if (Platform.isMacOS) {
@@ -270,6 +340,8 @@ void main() {
 
         await File(iosPath).delete();
         await macFile.delete();
+        // Clean up the project files to ensure the reconfigure command works
+        await cleanXcodeProjFiles(projectPath!);
       }
       final firebaseOptionsFile = await findFileInDirectory(
         p.join(projectPath!, 'lib'),
@@ -289,7 +361,10 @@ void main() {
 
       final accessToken = await generateAccessTokenCI();
 
-      Process.runSync(
+      // Clean up the project files to ensure the reconfigure command works
+      await cleanBuildGradleFiles(projectPath!);
+
+      final result2 = Process.runSync(
         'flutterfire',
         [
           'reconfigure',
@@ -298,10 +373,20 @@ void main() {
         workingDirectory: projectPath,
       );
 
+      if (result2.exitCode != 0) {
+        fail(result.stderr);
+      }
+
       testAndroidServiceFileValues(androidServiceFilePath);
       final firebaseOptionsPath =
           p.join(projectPath!, 'lib', 'firebase_options.dart');
       await testFirebaseOptionsFileValues(firebaseOptionsPath);
+
+      await checkBuildGradleFileUpdated(
+        projectPath!,
+        checkCrashlytics: true,
+        checkPerf: true,
+      );
 
       if (Platform.isMacOS) {
         await testAppleServiceFileValues(iosPath!);
@@ -309,6 +394,7 @@ void main() {
           macosPath!,
           platform: kMacos,
         );
+        await checkXcodeProjFiles(projectPath!);
       }
     },
     timeout: const Timeout(

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -436,8 +436,10 @@ Future<void> checkBuildGradleFileUpdated(
   final pluginsPattern = [
     '// START: FlutterFire Configuration',
     r"classpath 'com\.google\.gms:google-services:\d+\.\d+\.\d+'\s*",
-    if (checkPerf) r"classpath 'com\.google\.firebase:perf-plugin:\d+\.\d+\.\d+'\s*",
-    if (checkCrashlytics) r"classpath 'com\.google\.firebase:firebase-crashlytics-gradle:\d+\.\d+\.\d+'\s*",
+    if (checkPerf)
+      r"classpath 'com\.google\.firebase:perf-plugin:\d+\.\d+\.\d+'\s*",
+    if (checkCrashlytics)
+      r"classpath 'com\.google\.firebase:firebase-crashlytics-gradle:\d+\.\d+\.\d+'\s*",
     '// END: FlutterFire Configuration',
   ].join(r'\s*');
 
@@ -451,16 +453,20 @@ Future<void> checkBuildGradleFileUpdated(
 
   final androidAppBuildGradlePath =
       p.join(projectPath, 'android', 'app', 'build.gradle');
-  final androidAppBuildGradle = File(androidAppBuildGradlePath).readAsStringSync();
+  final androidAppBuildGradle =
+      File(androidAppBuildGradlePath).readAsStringSync();
   final pluginsPatternApp = [
     '// START: FlutterFire Configuration',
     r"(apply plugin: 'com\.google\.gms\.google-services'|id 'com\.google\.gms\.google-services')",
-    if (checkPerf) r"(apply plugin: 'com\.google\.firebase\.firebase-perf'|id 'com\.google\.firebase\.firebase-perf')",
-    if (checkCrashlytics) r"(apply plugin: 'com\.google\.firebase\.crashlytics'|id 'com\.google\.firebase\.crashlytics')",
+    if (checkPerf)
+      r"(apply plugin: 'com\.google\.firebase\.firebase-perf'|id 'com\.google\.firebase\.firebase-perf')",
+    if (checkCrashlytics)
+      r"(apply plugin: 'com\.google\.firebase\.crashlytics'|id 'com\.google\.firebase\.crashlytics')",
     '// END: FlutterFire Configuration',
   ].join(r'\s*');
 
-  final patternForApp = RegExp(pluginsPatternApp, multiLine: true, dotAll: true);
+  final patternForApp =
+      RegExp(pluginsPatternApp, multiLine: true, dotAll: true);
 
   final existsForApp = patternForApp.hasMatch(androidAppBuildGradle);
 

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -388,7 +388,6 @@ Future<void> cleanBuildGradleFiles(String projectPath) async {
   final androidAppBuildGradleContent =
       File(androidAppBuildGradle).readAsStringSync();
 
-// Remove the FlutterFire Configuration block
   final pattern = RegExp(
     r'\/\/ START: FlutterFire Configuration.*?\/\/ END: FlutterFire Configuration\s*\n',
     dotAll: true,
@@ -412,8 +411,6 @@ Future<void> cleanXcodeProjFiles(String projectPath) async {
   final iosContent = File(iosProj).readAsStringSync();
   final macosContent = File(macosProj).readAsStringSync();
 
-// Remove the FlutterFire Configuration block
-  // Define the regex pattern to match the FlutterFire section
   final pattern = RegExp(
     r'(\t[A-Z0-9]+ \/\* FlutterFire: "flutterfire upload-crashlytics-symbols" \*\/ = \{[\s\S]*?\n\t\t\};)',
   );
@@ -485,8 +482,6 @@ Future<void> checkXcodeProjFiles(String projectPath) async {
   final iosContent = File(iosProj).readAsStringSync();
   final macosContent = File(macosProj).readAsStringSync();
 
-// Remove the FlutterFire Configuration block
-  // Define the regex pattern to match the FlutterFire section
   final pattern = RegExp(
     r'(\t[A-Z0-9]+ \/\* FlutterFire: "flutterfire upload-crashlytics-symbols" \*\/ = \{[\s\S]*?\n\t\t\};)',
   );

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -379,6 +379,129 @@ void checkDartFirebaseJsonValues(
   }
 }
 
+Future<void> cleanBuildGradleFiles(String projectPath) async {
+  final androidBuildGradle = p.join(projectPath, 'android', 'build.gradle');
+  final androidAppBuildGradle =
+      p.join(projectPath, 'android', 'app', 'build.gradle');
+
+  final androidBuildGradleContent = File(androidBuildGradle).readAsStringSync();
+  final androidAppBuildGradleContent =
+      File(androidAppBuildGradle).readAsStringSync();
+
+// Remove the FlutterFire Configuration block
+  final pattern = RegExp(
+    r'\/\/ START: FlutterFire Configuration.*?\/\/ END: FlutterFire Configuration\s*\n',
+    dotAll: true,
+  );
+
+  final updatedContentBuildGradle =
+      androidBuildGradleContent.replaceAll(pattern, '');
+  final updatedContentAppBuildGradle =
+      androidAppBuildGradleContent.replaceAll(pattern, '');
+
+  File(androidBuildGradle).writeAsStringSync(updatedContentBuildGradle);
+  File(androidAppBuildGradle).writeAsStringSync(updatedContentAppBuildGradle);
+}
+
+Future<void> cleanXcodeProjFiles(String projectPath) async {
+  final iosProj =
+      p.join(projectPath, 'ios', 'Runner.xcodeproj', 'project.pbxproj');
+  final macosProj =
+      p.join(projectPath, 'macos', 'Runner.xcodeproj', 'project.pbxproj');
+
+  final iosContent = File(iosProj).readAsStringSync();
+  final macosContent = File(macosProj).readAsStringSync();
+
+// Remove the FlutterFire Configuration block
+  // Define the regex pattern to match the FlutterFire section
+  final pattern = RegExp(
+    r'(\t[A-Z0-9]+ \/\* FlutterFire: "flutterfire upload-crashlytics-symbols" \*\/ = \{[\s\S]*?\n\t\t\};)',
+  );
+
+  final updatedContentIos = iosContent.replaceAll(pattern, '');
+  final updatedContentMacos = macosContent.replaceAll(pattern, '');
+
+  File(iosProj).writeAsStringSync(updatedContentIos);
+  File(macosProj).writeAsStringSync(updatedContentMacos);
+}
+
+Future<void> checkBuildGradleFileUpdated(
+  String projectPath, {
+  bool checkPerf = false,
+  bool checkCrashlytics = false,
+}) async {
+  final androidBuildGradlePath = p.join(projectPath, 'android', 'build.gradle');
+  final androidBuildGradle = File(androidBuildGradlePath).readAsStringSync();
+
+  final pluginsPattern = [
+    '// START: FlutterFire Configuration',
+    r"classpath 'com\.google\.gms:google-services:\d+\.\d+\.\d+'\s*",
+    if (checkPerf) r"classpath 'com\.google\.firebase:perf-plugin:\d+\.\d+\.\d+'\s*",
+    if (checkCrashlytics) r"classpath 'com\.google\.firebase:firebase-crashlytics-gradle:\d+\.\d+\.\d+'\s*",
+    '// END: FlutterFire Configuration',
+  ].join(r'\s*');
+
+  final pattern = RegExp(pluginsPattern, multiLine: true, dotAll: true);
+
+  final exists = pattern.hasMatch(androidBuildGradle);
+
+  if (!exists) {
+    fail('android/build.gradle file was not updated as expected');
+  }
+
+  final androidAppBuildGradlePath =
+      p.join(projectPath, 'android', 'app', 'build.gradle');
+  final androidAppBuildGradle = File(androidAppBuildGradlePath).readAsStringSync();
+  final pluginsPatternApp = [
+    '// START: FlutterFire Configuration',
+    r"(apply plugin: 'com\.google\.gms\.google-services'|id 'com\.google\.gms\.google-services')",
+    if (checkPerf) r"(apply plugin: 'com\.google\.firebase\.firebase-perf'|id 'com\.google\.firebase\.firebase-perf')",
+    if (checkCrashlytics) r"(apply plugin: 'com\.google\.firebase\.crashlytics'|id 'com\.google\.firebase\.crashlytics')",
+    '// END: FlutterFire Configuration',
+  ].join(r'\s*');
+
+  final patternForApp = RegExp(pluginsPatternApp, multiLine: true, dotAll: true);
+
+  final existsForApp = patternForApp.hasMatch(androidAppBuildGradle);
+
+  if (!existsForApp) {
+    fail('android/app/build.gradle file was not updated as expected');
+  }
+}
+
+Future<void> checkXcodeProjFiles(String projectPath) async {
+  // This needs crashlytics dependency to be installed to work
+  final iosProj =
+      p.join(projectPath, 'ios', 'Runner.xcodeproj', 'project.pbxproj');
+  final macosProj =
+      p.join(projectPath, 'macos', 'Runner.xcodeproj', 'project.pbxproj');
+
+  final iosContent = File(iosProj).readAsStringSync();
+  final macosContent = File(macosProj).readAsStringSync();
+
+// Remove the FlutterFire Configuration block
+  // Define the regex pattern to match the FlutterFire section
+  final pattern = RegExp(
+    r'(\t[A-Z0-9]+ \/\* FlutterFire: "flutterfire upload-crashlytics-symbols" \*\/ = \{[\s\S]*?\n\t\t\};)',
+  );
+
+  final iosHasScript = pattern.hasMatch(iosContent);
+
+  if (!iosHasScript) {
+    fail(
+      'ios/Runner.xcodeproj/project.pbxproj file was not updated as expected',
+    );
+  }
+
+  final macosHasScript = pattern.hasMatch(macosContent);
+
+  if (!macosHasScript) {
+    fail(
+      'macos/Runner.xcodeproj/project.pbxproj file was not updated as expected',
+    );
+  }
+}
+
 // Use this variable to debug the process run commands in the integration tests
 // const kDebugProcess = false;
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I've decoupled the `build.gradle` file updates from the `FirebaseAndroidWrites` class in order to reuse the logic for `flutterfire reconfigure`. It is also much cleaner as it doesn't update a variable as a side effect, rather it passes the build.gradle content to the next function (e.g. crashlytics dependency build.gradle updates) and returns the string as updated for passing to the next function.

Apple was much easier to reuse, it just required passing in some class instance variables to the functions, it did not update variables as a side effect.

The large difference is; android only requires updating for the two build.gradle file, whilst apple depends on the users setup how we insert the crashlytics upload-symbol script. It requires updating for the different setups whether using `build-configuration`, `target` or `default` setup.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
