### PR TITLE
fix: allows firebase configuration file output path to be an absolute path

### DIFF
--- a/packages/flutterfire_cli/lib/src/common/prompts/dart_file_prompts.dart
+++ b/packages/flutterfire_cli/lib/src/common/prompts/dart_file_prompts.dart
@@ -12,10 +12,14 @@ String getFirebaseConfigurationFile({
   final segments = removeForwardBackwardSlash(configurationFilePath).split('/');
 
   if (segments.last.contains('.dart')) {
-    return path.join(
-      flutterAppPath,
-      removeForwardBackwardSlash(configurationFilePath),
-    );
+    if (path.isAbsolute(configurationFilePath)) {
+      return configurationFilePath;
+    } else {
+      return path.join(
+        flutterAppPath,
+        removeForwardBackwardSlash(configurationFilePath),
+      );
+    }
   } else {
     final configurationFilePath = promptInput(
       'Enter a path for your FirebaseOptions file. It must be to a dart file. Example input: lib/firebase_options.dart',

--- a/packages/flutterfire_cli/test/dart_file_prompts_test.dart
+++ b/packages/flutterfire_cli/test/dart_file_prompts_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutterfire_cli/src/common/prompts/dart_file_prompts.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() async {});
+
+  tearDown(() {});
+
+  test('getFirebaseConfigurationFile concatenates app path and config file', () async {
+    const configFile = 'configfile.dart';
+    const flutterAppPath = '/Users/username/Projects/flutter_app';
+
+    final firebaseConfigurationFile =
+        getFirebaseConfigurationFile(configurationFilePath: configFile, flutterAppPath: flutterAppPath);
+
+    expect(firebaseConfigurationFile, equals('/Users/username/Projects/flutter_app/configfile.dart'));
+  });
+
+  test(
+      'When configuration file path is absolute, getFirebaseConfigurationFile does not concatenate app path and config file',
+      () async {
+    const configFile = '/Users/username/Projects/test/configfile.dart';
+    const flutterAppPath = '/Users/username/Projects/flutter_app';
+
+    final firebaseConfigurationFile =
+        getFirebaseConfigurationFile(configurationFilePath: configFile, flutterAppPath: flutterAppPath);
+
+    expect(firebaseConfigurationFile, equals(configFile));
+  });
+}


### PR DESCRIPTION
## Description

When providing a custom firebase config dart file output path, this currently always gets joined to the current app path.

If that output path is an absolute path in a different directory to the app directory, it results in invalid paths such as:

`/Users/myuser/project/app/Users/myuser/differentproject/fireabse.dart`.

This fix tests if the path is absolute, and if so uses it directly. Tests are also added.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
