### PR TITLE
fix: Remove throwing an exception if appId/bundleId is not provided

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -279,7 +279,6 @@ class ConfigCommand extends FlutterFireCommand {
     final deprecatedValue = argResults!['android-app-id'] as String?;
 
     // TODO validate packagename is valid if provided.
-
     if (value != null) {
       return value;
     }
@@ -289,70 +288,31 @@ class ConfigCommand extends FlutterFireCommand {
       );
       return deprecatedValue;
     }
-
-    if (isCI) {
-      throw FirebaseCommandException(
-        'configure',
-        'Please provide value for android-package-name.',
-      );
-    }
     return null;
   }
 
   String? get iosBundleId {
     final value = argResults!['ios-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
-    if (value != null) return value;
-
-    if (isCI) {
-      throw FirebaseCommandException(
-        'configure',
-        'Please provide value for ios-bundle-id.',
-      );
-    }
-    return null;
+    return value;
   }
 
   String? get webAppId {
     final value = argResults!['web-app-id'] as String?;
-
-    if (value != null) return value;
-
-    if (isCI) {
-      throw FirebaseCommandException(
-        'configure',
-        'Please provide value for web-app-id.',
-      );
-    }
-    return null;
+    // TODO validate webAppId is valid if provided
+    return value;
   }
 
   String? get windowsAppId {
     final value = argResults![kWindowsAppIdFlag] as String?;
-
-    if (value != null) return value;
-
-    if (isCI) {
-      throw FirebaseCommandException(
-        'configure',
-        'Please provide value for $kWindowsAppIdFlag.',
-      );
-    }
-    return null;
+    // TODO validate windowsAppId is valid if provided
+    return value;
   }
 
   String? get macosBundleId {
     final value = argResults!['macos-bundle-id'] as String?;
     // TODO validate bundleId is valid if provided
-    if (value != null) return value;
-
-    if (isCI) {
-      throw FirebaseCommandException(
-        'configure',
-        'Please provide value for macos-bundle-id.',
-      );
-    }
-    return null;
+    return value;
   }
 
   String? get token {


### PR DESCRIPTION
## Description

If a platform's appId/bundleId is not provided, an exception will be thrown inside a CI environment.

There was a partial fix for the mandatory flag by https://github.com/invertase/flutterfire_cli/pull/179 but it's not completely fixed as an exception will still be thrown:

![](https://user-images.githubusercontent.com/70890146/284092348-fe01f79c-e6a1-4341-b797-fa18a58f562c.png)


This should fix https://github.com/invertase/flutterfire_cli/issues/233

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
