### PR TITLE
fix(apple): upload debug symbols for de-obfuscating Dart stack traces

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -90,6 +90,55 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       help:
           'Value is always ""default". This is for backwards compatibility of default configuration',
     );
+
+    argParser.addOption(
+      'env-platform-name',
+      valueHelp: 'envPlatformName',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-configuration',
+      valueHelp: 'envConfiguration',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-project-dir',
+      valueHelp: 'envProjectDir',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-built-products-dir',
+      valueHelp: 'envBuildProductsDir',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-dwarf-dsym-folder-path',
+      valueHelp: 'envDwarfDsymFolderPath',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-dwarf-dsym-file-name',
+      valueHelp: 'envDwarfDsymFileName',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
+    
+    argParser.addOption(
+      'env-infoplist-path',
+      valueHelp: 'envInfoPlistPath',
+      help:
+          'Required environment variable for running `upload-symbols` script.',
+    );
   }
 
   @override
@@ -106,12 +155,32 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     return argResults!['upload-symbols-script-path'] as String;
   }
 
-  String get debugSymbolsPath {
-    return argResults!['debug-symbols-path'] as String;
+  String get envPlatformName {
+    return argResults!['env-platform-name'] as String;
   }
 
-  String get infoPlistPath {
-    return argResults!['info-plist-path'] as String;
+  String get envConfiguration {
+    return argResults!['env-configuration'] as String;
+  }
+
+  String get envProjectDir {
+    return argResults!['env-project-dir'] as String;
+  }
+
+  String get envBuildProductsDir {
+    return argResults!['env-built-products-dir'] as String;
+  }
+  
+  String get envDwarfDsymFolderPath {
+    return argResults!['env-dwarf-dsym-folder-path'] as String;
+  }
+  
+  String get envDwarfDsymFileName {
+    return argResults!['env-dwarf-dsym-file-name'] as String;
+  }
+  
+  String get envInfoPlistPath {
+    return argResults!['env-infoplist-path'] as String;
   }
 
   String? get buildConfiguration {
@@ -284,14 +353,19 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     final validationScript = await Process.run(
       uploadSymbolsScriptPath,
       [
-        '--build-phase',
         '--validate',
-        '-ai',
-        appId,
         '--flutter-project',
         appIdFilePath,
-        debugSymbolsPath,
       ],
+      environment: {
+        'PLATFORM_NAME': envPlatformName,
+        'CONFIGURATION': envConfiguration,
+        'PROJECT_DIR': envProjectDir,
+        'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
+        'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,
+        'INFOPLIST_PATH': envInfoPlistPath,
+        'BUILT_PRODUCTS_DIR': envBuildProductsDir,
+      },
     );
 
     if (validationScript.exitCode != 0) {
@@ -299,16 +373,21 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     }
 
     // Upload script
-    final uploadScript = await Process.run(
+     final uploadScript = await Process.run(
       uploadSymbolsScriptPath,
       [
-        '--build-phase',
-        '-ai',
-        appId,
         '--flutter-project',
-        appIdFilePath,
-        debugSymbolsPath,
+        appIdFilePath, 
       ],
+      environment: {
+        'PLATFORM_NAME': envPlatformName,
+        'CONFIGURATION': envConfiguration,
+        'PROJECT_DIR': envProjectDir,
+        'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
+        'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,
+        'INFOPLIST_PATH': envInfoPlistPath,
+        'BUILT_PRODUCTS_DIR': envBuildProductsDir,
+      },
     );
 
     if (uploadScript.exitCode != 0) {
@@ -316,6 +395,7 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     }
 
     if (uploadScript.stdout != null) {
+      stdout.write(uploadScript.stdout as String);
       logger.stdout(uploadScript.stdout as String);
     }
   }

--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -97,42 +97,42 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-configuration',
       valueHelp: 'envConfiguration',
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-project-dir',
       valueHelp: 'envProjectDir',
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-built-products-dir',
       valueHelp: 'envBuildProductsDir',
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-dwarf-dsym-folder-path',
       valueHelp: 'envDwarfDsymFolderPath',
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-dwarf-dsym-file-name',
       valueHelp: 'envDwarfDsymFileName',
       help:
           'Required environment variable for running `upload-symbols` script.',
     );
-    
+
     argParser.addOption(
       'env-infoplist-path',
       valueHelp: 'envInfoPlistPath',
@@ -170,15 +170,15 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
   String get envBuildProductsDir {
     return argResults!['env-built-products-dir'] as String;
   }
-  
+
   String get envDwarfDsymFolderPath {
     return argResults!['env-dwarf-dsym-folder-path'] as String;
   }
-  
+
   String get envDwarfDsymFileName {
     return argResults!['env-dwarf-dsym-file-name'] as String;
   }
-  
+
   String get envInfoPlistPath {
     return argResults!['env-infoplist-path'] as String;
   }
@@ -373,11 +373,11 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     }
 
     // Upload script
-     final uploadScript = await Process.run(
+    final uploadScript = await Process.run(
       uploadSymbolsScriptPath,
       [
         '--flutter-project',
-        appIdFilePath, 
+        appIdFilePath,
       ],
       environment: {
         'PLATFORM_NAME': envPlatformName,

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -374,7 +374,7 @@ String _debugSymbolsScript(
   String platform,
 ) {
   var command =
-      'flutterfire upload-crashlytics-symbols --upload-symbols-script-path=\$PODS_ROOT/FirebaseCrashlytics/upload-symbols --debug-symbols-path=\${DWARF_DSYM_FOLDER_PATH}/\${DWARF_DSYM_FILE_NAME} --info-plist-path=\${SRCROOT}/\${BUILT_PRODUCTS_DIR}/\${INFOPLIST_PATH} --platform=$platform --apple-project-path=\${SRCROOT} ';
+      'flutterfire upload-crashlytics-symbols --upload-symbols-script-path=\$PODS_ROOT/FirebaseCrashlytics/upload-symbols --platform=$platform --apple-project-path=\${SRCROOT} --env-platform-name=\${PLATFORM_NAME} --env-configuration=\${CONFIGURATION} --env-project-dir=\${PROJECT_DIR} --env-built-products-dir=\${BUILT_PRODUCTS_DIR} --env-dwarf-dsym-folder-path=\${DWARF_DSYM_FOLDER_PATH} --env-dwarf-dsym-file-name=\${DWARF_DSYM_FILE_NAME} --env-infoplist-path=\${INFOPLIST_PATH} ';
 
   switch (projectConfiguration) {
     case ProjectConfiguration.buildConfiguration:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I've tested on two fresh apps using the '--obfuscate' flag. Confirmed that this fixes the Dart stack trace:
<img width="986" alt="Screenshot 2023-12-18 at 12 41 40" src="https://github.com/invertase/flutterfire_cli/assets/16018629/1ad0fe7c-56ce-4a89-8237-2b62420e8bba">
<img width="1253" alt="Screenshot 2023-12-18 at 12 42 06" src="https://github.com/invertase/flutterfire_cli/assets/16018629/80f12308-0a6b-4a0e-95a7-8488bc4979c8">

also able to see it in the build logs when running: `flutter build --verbose | tee build.log`

```
Running upload-symbols in Build Phase mode
           [33mwarning: Flutter build with '--obfuscate' enabled. To view deobfuscated stack traces, upgrade to Flutter 3.12.0+ or upload dSYMs manually using the Firebase console web uploader at https://firebase.google.com/project/_/crashlytics[0m
           Validating build environment for Crashlytics...
           Processing dSYMs...
           Successfully submitted symbols for architecture arm64 with UUID dd9d9a4b88a8358eb1b0beea3f1f8800 in dSYM: /Users/russellwheatley/projects/devTests/third_crash_test/build/ios/Release-iphoneos/Runner.app.dSYM
           Successfully submitted symbols for architecture arm64 with UUID 3b985343b91b37e7b78ac3a0cb66459b in dSYM: /Users/russellwheatley/projects/devTests/third_crash_test/build/ios/Release-iphoneos/App.framework.dSYM
           [32mSuccessfully uploaded Crashlytics build event and symbols[0m
           Running upload-symbols in Build Phase mode
           [33mwarning: Flutter build with '--obfuscate' enabled. To view deobfuscated stack traces, upgrade to Flutter 3.12.0+ or upload dSYMs manually using the Firebase console web uploader at https://firebase.google.com/project/_/crashlytics[0m
           Validating build environment for Crashlytics...
           Processing dSYMs...
           Successfully submitted symbols for architecture arm64 with UUID dd9d9a4b88a8358eb1b0beea3f1f8800 in dSYM: /Users/russellwheatley/projects/devTests/third_crash_test/build/ios/Release-iphoneos/Runner.app.dSYM
           Successfully submitted symbols for architecture arm64 with UUID 3b985343b91b37e7b78ac3a0cb66459b in dSYM: /Users/russellwheatley/projects/devTests/third_crash_test/build/ios/Release-iphoneos/App.framework.dSYM
           [32mSuccessfully uploaded Crashlytics build event and symbols[0m
```

fix: https://github.com/invertase/flutterfire_cli/issues/246

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
