### PR TITLE
fix(android): another `build.gradle` change in latest flutter (>=3.16.5) when running `flutter create <project>`

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -381,7 +381,6 @@ AndroidGradleContents _applyGoogleServicesPlugin(
     if (match.group(0) != null) {
       if (buildGradleConfiguration == BuildGradleConfiguration.legacy2 ||
           buildGradleConfiguration == BuildGradleConfiguration.latest) {
-        print('YYYYYYY');
         // This is legacy2 & latest
         // If matched pattern is 'id "com.android.application"'
         return "${match.group(0)}\n    $_flutterFireConfigCommentStart\n    id '$_googleServicesPluginName'\n    $_flutterFireConfigCommentEnd";
@@ -409,7 +408,7 @@ AndroidGradleContents _applyGoogleServicesPlugin(
         // Find the index where to insert the new line
         final endIndex = match.end;
         final toInsert = _applyGradleSettingsDependency(
-          _googleServicesPluginClass,
+          _googleServicesPluginName,
           _googleServicesPluginVersion,
           flutterfireComments: true,
         );
@@ -547,7 +546,8 @@ AndroidGradleContents _applyFirebaseAndroidPlugin({
 
     if (!pluginExists) {
       final pattern = RegExp(
-          r'id "com\.google\.gms:google-services" version "\d+\.\d+\.\d+" apply false');
+        r'id "com\.google\.gms\.google-services" version "\d+\.\d+\.\d+" apply false',
+      );
 
       final match = pattern.firstMatch(androidGradleSettingsFileContents);
 
@@ -555,7 +555,10 @@ AndroidGradleContents _applyFirebaseAndroidPlugin({
         // Find the index where to insert the new line
         final endIndex = match.end;
         final toInsert = _applyGradleSettingsDependency(
-          pluginClassPath,
+          // Need to use plugin class rather than plugin class path in settings.gradle
+          pluginClassPath.contains('crashlytics')
+              ? _crashlyticsPluginClass
+              : _performancePluginClass,
           pluginClassPathVersion,
         );
 

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -484,7 +484,7 @@ AndroidGradleContents _applyFirebaseAndroidPlugin({
         );
       }
     } else {
-      // TODO already contains plugin, should we upgrade version?
+      // Already applied.
       return AndroidGradleContents(
         buildGradleContent: androidBuildGradleFileContents,
         appBuildGradleContent: androidAppBuildGradleFileContents,

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -220,7 +220,6 @@ Future<void> gradleContentUpdates(
   // We check if "apply plugin: 'com.android.application'" is present in the android/app/build.gradle file
   if (androidAppBuildGradleFileContents
       .contains("apply plugin: 'com.android.application'")) {
-    print('legacy1');
     content = _applyGoogleServicesPlugin(
       flutterApp,
       content,
@@ -247,7 +246,6 @@ Future<void> gradleContentUpdates(
           .contains('id "com.android.application"') &&
       !androidAppBuildGradleFileContents
           .contains("apply plugin: 'com.android.application'")) {
-    print('legacy2');
     content = _applyGoogleServicesPlugin(
       flutterApp,
       content,
@@ -272,7 +270,6 @@ Future<void> gradleContentUpdates(
   // We check if plugins block containing "id "com.android.application"" is present in the android/settings.gradle file
   if (androidGradleSettingsFileContents
       .contains('id "com.android.application"')) {
-    print('latest');
     content = _applyGoogleServicesPlugin(
       flutterApp,
       content,

--- a/packages/flutterfire_cli/test/configure_test.dart
+++ b/packages/flutterfire_cli/test/configure_test.dart
@@ -162,33 +162,8 @@ void main() {
       );
       testAndroidServiceFileValues(androidServiceFilePath);
 
-      // Check android "android/build.gradle" & "android/app/build.gradle" were updated
-
-      final androidBuildGradle =
-          p.join(projectPath!, 'android', 'build.gradle');
-      final androidAppBuildGradle =
-          p.join(projectPath!, 'android', 'app', 'build.gradle');
-
-      final androidBuildGradleContent =
-          normalizeLineEndings(await File(androidBuildGradle).readAsString());
-
-      final androidAppBuildGradleContent = normalizeLineEndings(
-        await File(androidAppBuildGradle).readAsString(),
-      );
-
-      final buildGradleLines = androidGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidBuildGradleContent, buildGradleLines),
-        isTrue,
-      );
-
-      final appBuildGradleLines = androidAppGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidAppBuildGradleContent, appBuildGradleLines),
-        isTrue,
-      );
+      // Check android "android/settings.gradle" & "android/app/build.gradle" were updated
+      await checkBuildGradleFileUpdated(projectPath!);
 
       // check "firebase_options.dart" file is created in lib directory
       final firebaseOptions =
@@ -358,32 +333,8 @@ void main() {
       );
       testAndroidServiceFileValues(androidServiceFilePath);
 
-      // Check android "android/build.gradle" & "android/app/build.gradle" were updated
-      final androidBuildGradle =
-          p.join(projectPath!, 'android', 'build.gradle');
-      final androidAppBuildGradle =
-          p.join(projectPath!, 'android', 'app', 'build.gradle');
-
-      final androidBuildGradleContent =
-          normalizeLineEndings(await File(androidBuildGradle).readAsString());
-
-      final androidAppBuildGradleContent = normalizeLineEndings(
-        await File(androidAppBuildGradle).readAsString(),
-      );
-
-      final buildGradleLines = androidGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidBuildGradleContent, buildGradleLines),
-        isTrue,
-      );
-
-      final appBuildGradleLines = androidAppGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidAppBuildGradleContent, appBuildGradleLines),
-        isTrue,
-      );
+      // Check android "android/settings.gradle" & "android/app/build.gradle" were updated
+      await checkBuildGradleFileUpdated(projectPath!);
 
       // check "firebase_options.dart" file is created in lib directory
       final firebaseOptions =
@@ -549,32 +500,8 @@ void main() {
       );
       testAndroidServiceFileValues(androidServiceFilePath);
 
-      // Check android "android/build.gradle" & "android/app/build.gradle" were updated
-      final androidBuildGradle =
-          p.join(projectPath!, 'android', 'build.gradle');
-      final androidAppBuildGradle =
-          p.join(projectPath!, 'android', 'app', 'build.gradle');
-
-      final androidBuildGradleContent =
-          normalizeLineEndings(await File(androidBuildGradle).readAsString());
-
-      final androidAppBuildGradleContent = normalizeLineEndings(
-        await File(androidAppBuildGradle).readAsString(),
-      );
-
-      final buildGradleLines = androidGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidBuildGradleContent, buildGradleLines),
-        isTrue,
-      );
-
-      final appBuildGradleLines = androidAppGradleUpdate.trim().split('\n');
-
-      expect(
-        containsInOrder(androidAppBuildGradleContent, appBuildGradleLines),
-        isTrue,
-      );
+      // Check android "android/settings.gradle" & "android/app/build.gradle" were updated
+      await checkBuildGradleFileUpdated(projectPath!);
 
       // check "firebase_options.dart" file is created in lib directory
       final firebaseOptions =

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -438,16 +438,17 @@ Future<void> checkBuildGradleFileUpdated(
   bool checkPerf = false,
   bool checkCrashlytics = false,
 }) async {
-  final androidBuildGradlePath = p.join(projectPath, 'android', 'build.gradle');
-  final androidBuildGradle = File(androidBuildGradlePath).readAsStringSync();
+  final androidSettingsGradlePath =
+      p.join(projectPath, 'android', 'settings.gradle');
+  final androidBuildGradle = File(androidSettingsGradlePath).readAsStringSync();
 
   final pluginsPattern = [
     '// START: FlutterFire Configuration',
-    r"classpath 'com\.google\.gms:google-services:\d+\.\d+\.\d+'\s*",
+    r'id "com\.google\.gms\.google-services" version "\d+\.\d+\.\d+" apply false',
     if (checkPerf)
-      r"classpath 'com\.google\.firebase:perf-plugin:\d+\.\d+\.\d+'\s*",
+      r'id "com\.google\.firebase\.firebase-perf" version "\d+\.\d+\.\d+" apply false',
     if (checkCrashlytics)
-      r"classpath 'com\.google\.firebase:firebase-crashlytics-gradle:\d+\.\d+\.\d+'\s*",
+      r'id "com\.google\.firebase\.crashlytics" version "\d+\.\d+\.\d+" apply false',
     '// END: FlutterFire Configuration',
   ].join(r'\s*');
 
@@ -456,7 +457,7 @@ Future<void> checkBuildGradleFileUpdated(
   final exists = pattern.hasMatch(androidBuildGradle);
 
   if (!exists) {
-    fail('android/build.gradle file was not updated as expected');
+    fail('android/settings.gradle file was not updated as expected');
   }
 
   final androidAppBuildGradlePath =


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

fixes https://github.com/invertase/flutterfire_cli/issues/251

there are now 2 legacy ways to update the gradle configuration and the latest Flutter version requires updating the `settings.gradle` file rather than `android/build.gradle` which you can [read more about here](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply). I've refactored the gradle writing to make it clearer what is being updated. Hence why there is now an enum for each different gradle configuration.

I've tested against all three types. At the moment, the CI only tests against the latest and perhaps if there is a bigger use case, I will test against legacy Flutter versions which create different gradle configurations.

Below are the results of running `flutterfire configure --yes --project=project-id --platforms=android` against all 3 different gradle configurations:

## Legacy gradle configuration 1

`android/app/build.gradle`:

```groovy
apply plugin: 'com.android.application'  
// START: FlutterFire Configuration  
apply plugin: 'com.google.gms.google-services'  
apply plugin: 'com.google.firebase.crashlytics'  
// END: FlutterFire Configuration  
apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
```

`android/build.gradle`:
```groovy
dependencies {  
    // START: FlutterFire Configuration  
    classpath 'com.google.gms:google-services:4.3.15'  
    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'  
    // END: FlutterFire Configuration  
    classpath 'com.android.tools.build:gradle:8.1.2'  
}
```

## Legacy gradle configuration 2

`android/build.gradle`:

```groovy
    dependencies {
        // START: FlutterFire Configuration
        classpath 'com.google.gms:google-services:4.3.15'
        classpath 'com.google.firebase:perf-plugin:1.4.1'
        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
        // END: FlutterFire Configuration
        classpath 'com.android.tools.build:gradle:7.3.0'
        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
    }
```

`android/app/build.gradle`:

```groovy
plugins {
    id "com.android.application"
    // START: FlutterFire Configuration
    id 'com.google.gms.google-services'
    id 'com.google.firebase.firebase-perf'
    id 'com.google.firebase.crashlytics'
    // END: FlutterFire Configuration
    id "kotlin-android"
    id "dev.flutter.flutter-gradle-plugin"
}
```

## Latest Flutter version >= 3.16.5

`android/app/build.gradle`:

```groovy
plugins {
    id "com.android.application"
    // START: FlutterFire Configuration
    id 'com.google.gms.google-services'
    id 'com.google.firebase.firebase-perf'
    id 'com.google.firebase.crashlytics'
    // END: FlutterFire Configuration
    id "kotlin-android"
    id "dev.flutter.flutter-gradle-plugin"
}
```

`android/settings.gradle`:
```
plugins {
    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
    id "com.android.application" version "7.3.0" apply false
    // START: FlutterFire Configuration
    id "com.google.gms:google-services" version "4.3.15" apply false
    id "com.google.firebase:perf-plugin" version "1.4.1" apply false
    id "com.google.firebase:firebase-crashlytics-gradle" version "2.8.1" apply false
    // END: FlutterFire Configuration
}
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
