### PR TITLE
fix: Raised Firebase project fetch timeout to 40 seconds from 15 seconds.

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -453,7 +453,7 @@ class ConfigCommand extends FlutterFireCommand {
             token: token,
             serviceAccount: serviceAccount,
           )
-          .timeout(const Duration(minutes:1));
+          .timeout(const Duration(seconds: 40));
 
       fetchingProjectsSpinner.done();
 

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -453,7 +453,7 @@ class ConfigCommand extends FlutterFireCommand {
             token: token,
             serviceAccount: serviceAccount,
           )
-          .timeout(const Duration(seconds: 15));
+          .timeout(const Duration(minutes:1));
 
       fetchingProjectsSpinner.done();
 


### PR DESCRIPTION
## Description

Fetching project takes some time and 15s always result in a timeout. raised timeout to 1 minute

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
