### PR TITLE
fix: ensure Crashlytics Apple upload-symbol script works for every build type/flavor

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -371,7 +371,15 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     if (validationScript.exitCode != 0) {
       throw Exception(validationScript.stderr);
     }
-
+    print('uploadSymbolsScriptPath: $uploadSymbolsScriptPath');
+    print('appIdFilePath: $appIdFilePath');
+    print('envPlatformName: $envPlatformName');
+    print('envConfiguration: $envConfiguration');
+    print('envProjectDir: $envProjectDir');
+    print('envDwarfDsymFolderPath: $envDwarfDsymFolderPath');
+    print('envDwarfDsymFileName: $envDwarfDsymFileName');
+    print('envInfoPlistPath: $envInfoPlistPath');
+    print('envBuildProductsDir: $envBuildProductsDir');
     // Upload script
     final uploadScript = await Process.run(
       uploadSymbolsScriptPath,

--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -359,7 +359,8 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       ],
       environment: {
         'PLATFORM_NAME': envPlatformName,
-        'CONFIGURATION': envConfiguration,
+        // Hard code "Release" to ensure "App.framework.dsym" is uploaded and complies with upload-symbol script
+        'CONFIGURATION': 'Release',
         'PROJECT_DIR': envProjectDir,
         'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
         'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,
@@ -371,15 +372,6 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     if (validationScript.exitCode != 0) {
       throw Exception(validationScript.stderr);
     }
-    print('uploadSymbolsScriptPath: $uploadSymbolsScriptPath');
-    print('appIdFilePath: $appIdFilePath');
-    print('envPlatformName: $envPlatformName');
-    print('envConfiguration: $envConfiguration');
-    print('envProjectDir: $envProjectDir');
-    print('envDwarfDsymFolderPath: $envDwarfDsymFolderPath');
-    print('envDwarfDsymFileName: $envDwarfDsymFileName');
-    print('envInfoPlistPath: $envInfoPlistPath');
-    print('envBuildProductsDir: $envBuildProductsDir');
     // Upload script
     final uploadScript = await Process.run(
       uploadSymbolsScriptPath,
@@ -389,7 +381,8 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       ],
       environment: {
         'PLATFORM_NAME': envPlatformName,
-        'CONFIGURATION': envConfiguration,
+        // Hard code "Release" to ensure "App.framework.dsym" is uploaded and complies with upload-symbol script
+        'CONFIGURATION': 'Release',
         'PROJECT_DIR': envProjectDir,
         'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
         'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,

--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -349,6 +349,18 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     );
     final appIdFilePath =
         await _findOrCreateAppIdFile(appIdFileDirectory, appId, projectId);
+
+    final appFrameworkDsymPath = path.join(
+      envBuildProductsDir,
+      'App.framework.dSYM',
+    );
+
+    final buildDirectory = Directory(appFrameworkDsymPath);
+
+    // Set configuration to "Release" if "App.framework.dSYM" exists. Otherwise, "Debug". This is to ensure successful upload of symbols
+    final buildConfiguration =
+        buildDirectory.existsSync() ? 'Release' : 'Debug';
+
     // Validation script
     final validationScript = await Process.run(
       uploadSymbolsScriptPath,
@@ -359,8 +371,7 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       ],
       environment: {
         'PLATFORM_NAME': envPlatformName,
-        // Hard code "Release" to ensure "App.framework.dsym" is uploaded and complies with upload-symbol script
-        'CONFIGURATION': 'Release',
+        'CONFIGURATION': buildConfiguration,
         'PROJECT_DIR': envProjectDir,
         'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
         'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,
@@ -372,6 +383,7 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     if (validationScript.exitCode != 0) {
       throw Exception(validationScript.stderr);
     }
+
     // Upload script
     final uploadScript = await Process.run(
       uploadSymbolsScriptPath,
@@ -381,8 +393,7 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
       ],
       environment: {
         'PLATFORM_NAME': envPlatformName,
-        // Hard code "Release" to ensure "App.framework.dsym" is uploaded and complies with upload-symbol script
-        'CONFIGURATION': 'Release',
+        'CONFIGURATION': buildConfiguration,
         'PROJECT_DIR': envProjectDir,
         'DWARF_DSYM_FOLDER_PATH': envDwarfDsymFolderPath,
         'DWARF_DSYM_FILE_NAME': envDwarfDsymFileName,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

fixes: https://github.com/invertase/flutterfire_cli/issues/249


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
