### PR TITLE
fix: running configure generates an infinite amount of apply plugin strings

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -352,7 +352,7 @@ AndroidGradleContents _applyGoogleServicesPlugin(
     androidBuildGradleFileContents = updatedContent.buildGradleContent;
   }
 
-  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginClass)) {
+  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginName)) {
     final hasMatch =
         _androidAppBuildGradleRegex.hasMatch(androidAppBuildGradleFileContents);
     if (!hasMatch) {


### PR DESCRIPTION
## Description

This PR fixes android apply plugin check

Now it generates apply plugin string even if it's already in the build.gradle because of the wrong check.
Like this
`
// START: FlutterFire Configuration
apply plugin: 'com.google.gms.google-services'
// END: FlutterFire Configuration
// START: FlutterFire Configuration
apply plugin: 'com.google.gms.google-services'
// END: FlutterFire Configuration
`

It checks `com.google.gms:google-services` instead of `com.google.gms.google-services` in non legacy `_applyGoogleServicesPlugin` method

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
