### PR TITLE
fix(android): ensure app/build.gradle only writes google services dependency once

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -372,25 +372,27 @@ AndroidGradleContents _applyGoogleServicesPlugin(
     );
   }
 
-  androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
-      .replaceFirstMapped(_androidAppBuildGradleRegex, (match) {
-    // Check which pattern was matched and insert the appropriate content
-    if (match.group(0) != null) {
-      if (buildGradleConfiguration == BuildGradleConfiguration.legacy2 ||
-          buildGradleConfiguration == BuildGradleConfiguration.latest) {
-        // This is legacy2 & latest
-        // If matched pattern is 'id "com.android.application"'
-        return "${match.group(0)}\n    $_flutterFireConfigCommentStart\n    id '$_googleServicesPluginName'\n    $_flutterFireConfigCommentEnd";
-      } else {
-        // This is legacy1
-        // If matched pattern is 'apply plugin:...'
-        return "${match.group(0)}\n$_flutterFireConfigCommentStart\napply plugin: '$_googleServicesPluginName'\n$_flutterFireConfigCommentEnd";
+  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginName)) {
+    androidAppBuildGradleFileContents = androidAppBuildGradleFileContents
+        .replaceFirstMapped(_androidAppBuildGradleRegex, (match) {
+      // Check which pattern was matched and insert the appropriate content
+      if (match.group(0) != null) {
+        if (buildGradleConfiguration == BuildGradleConfiguration.legacy2 ||
+            buildGradleConfiguration == BuildGradleConfiguration.latest) {
+          // This is legacy2 & latest
+          // If matched pattern is 'id "com.android.application"'
+          return "${match.group(0)}\n    $_flutterFireConfigCommentStart\n    id '$_googleServicesPluginName'\n    $_flutterFireConfigCommentEnd";
+        } else {
+          // This is legacy1
+          // If matched pattern is 'apply plugin:...'
+          return "${match.group(0)}\n$_flutterFireConfigCommentStart\napply plugin: '$_googleServicesPluginName'\n$_flutterFireConfigCommentEnd";
+        }
       }
-    }
-    throw Exception(
-      'Could not match pattern in android/app `build.gradle` file for plugin $_googleServicesPluginName',
-    );
-  });
+      throw Exception(
+        'Could not match pattern in android/app `build.gradle` file for plugin $_googleServicesPluginName',
+      );
+    });
+  }
 
   if (buildGradleConfiguration == BuildGradleConfiguration.latest) {
     final pluginExists = androidGradleSettingsFileContents

--- a/packages/flutterfire_cli/test/configure_test.dart
+++ b/packages/flutterfire_cli/test/configure_test.dart
@@ -1437,4 +1437,65 @@ void main() {
       Duration(minutes: 2),
     ),
   );
+
+  test(
+      'flutterfire configure: ensure android build.gradle files are only updated once',
+      () async {
+    // Add crashlytics and performance to check they are only created once
+    final result = Process.runSync(
+      'flutter',
+      ['pub', 'add', 'firebase_crashlytics', 'firebase_performance'],
+      workingDirectory: projectPath,
+    );
+
+    if (result.exitCode != 0) {
+      fail(result.stderr as String);
+    }
+    // Run first time to update
+    Process.runSync(
+      'flutterfire',
+      [
+        'configure',
+        '--yes',
+        // Only android
+        '--platforms=android',
+        '--ios-bundle-id=com.example.flutterTestCli',
+        '--android-package-name=com.example.flutter_test_cli',
+        '--macos-bundle-id=com.example.flutterTestCli',
+        '--web-app-id=$webAppId',
+        '--windows-app-id=$windowsAppId',
+        '--project=$firebaseProjectId',
+      ],
+      workingDirectory: projectPath,
+      runInShell: true,
+    );
+    // Run second time and check it was only updated once
+    final result2 = Process.runSync(
+      'flutterfire',
+      [
+        'configure',
+        '--yes',
+        // Only android
+        '--platforms=android',
+        '--ios-bundle-id=com.example.flutterTestCli',
+        '--android-package-name=com.example.flutter_test_cli',
+        '--macos-bundle-id=com.example.flutterTestCli',
+        '--web-app-id=$webAppId',
+        '--windows-app-id=$windowsAppId',
+        '--project=$firebaseProjectId',
+      ],
+      workingDirectory: projectPath,
+      runInShell: true,
+    );
+
+    if (result2.exitCode != 0) {
+      fail(result2.stderr as String);
+    }
+
+    await checkBuildGradleFileUpdated(
+      projectPath!,
+      checkCrashlytics: true,
+      checkPerf: true,
+    );
+  });
 }

--- a/packages/flutterfire_cli/test/test_utils.dart
+++ b/packages/flutterfire_cli/test/test_utils.dart
@@ -438,11 +438,12 @@ Future<void> checkBuildGradleFileUpdated(
   bool checkPerf = false,
   bool checkCrashlytics = false,
 }) async {
+  // Check android/settings.gradle
   final androidSettingsGradlePath =
       p.join(projectPath, 'android', 'settings.gradle');
   final androidBuildGradle = File(androidSettingsGradlePath).readAsStringSync();
 
-  final pluginsPattern = [
+  final pluginsPatternSettings = [
     '// START: FlutterFire Configuration',
     r'id "com\.google\.gms\.google-services" version "\d+\.\d+\.\d+" apply false',
     if (checkPerf)
@@ -452,18 +453,25 @@ Future<void> checkBuildGradleFileUpdated(
     '// END: FlutterFire Configuration',
   ].join(r'\s*');
 
-  final pattern = RegExp(pluginsPattern, multiLine: true, dotAll: true);
+  final patternSettings =
+      RegExp(pluginsPatternSettings, multiLine: true, dotAll: true);
 
-  final exists = pattern.hasMatch(androidBuildGradle);
+  final matchesSettings = patternSettings.allMatches(androidBuildGradle);
 
-  if (!exists) {
+  if (matchesSettings.isEmpty) {
     fail('android/settings.gradle file was not updated as expected');
+  } else if (matchesSettings.length > 1) {
+    fail(
+      'android/settings.gradle file contains duplicate FlutterFire configurations',
+    );
   }
 
+  // Check android/app/build.gradle
   final androidAppBuildGradlePath =
       p.join(projectPath, 'android', 'app', 'build.gradle');
   final androidAppBuildGradle =
       File(androidAppBuildGradlePath).readAsStringSync();
+
   final pluginsPatternApp = [
     '// START: FlutterFire Configuration',
     r"(apply plugin: 'com\.google\.gms\.google-services'|id 'com\.google\.gms\.google-services')",
@@ -477,10 +485,14 @@ Future<void> checkBuildGradleFileUpdated(
   final patternForApp =
       RegExp(pluginsPatternApp, multiLine: true, dotAll: true);
 
-  final existsForApp = patternForApp.hasMatch(androidAppBuildGradle);
+  final matchesForApp = patternForApp.allMatches(androidAppBuildGradle);
 
-  if (!existsForApp) {
+  if (matchesForApp.isEmpty) {
     fail('android/app/build.gradle file was not updated as expected');
+  } else if (matchesForApp.length > 1) {
+    fail(
+      'android/app/build.gradle file contains duplicate FlutterFire configurations',
+    );
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Wrapped google-services plugin write to check if file already contains `google-services` dependency like we do for other dependency writes; crashlytics and perf mon.

fix: https://github.com/invertase/flutterfire_cli/issues/267

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
