### PR TITLE
chore: updated http dependency range

### DIFF
--- a/packages/flutterfire_cli/pubspec.yaml
+++ b/packages/flutterfire_cli/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cli_util: ^0.4.0
   deep_pick: ^1.0.0
   file: ^6.1.2
-  http: ^0.13.5
+  http: ">=0.13.5 <2.0.0"
   interact: ^2.1.1
   meta: ^1.7.0
   path: ^1.8.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Updates the `http` package range to allow `>= 1.0.0 <2.0.0`. A version range is necessary as current `pub_updater` depends on `http: ^0.13.5`.

resolves #255

Will follow-up with 2 more PRs to update `pub_updater` and then change `http` version to `^1.2.1`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
