### PR TITLE
fix: `resources` property can be `null` in newer Firebase projects if no products have been enabled on the project

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/base.dart
+++ b/packages/flutterfire_cli/lib/src/commands/base.dart
@@ -19,13 +19,16 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
 
+import '../common/config.dart';
 import '../common/strings.dart';
 import '../common/utils.dart';
 import '../flutter_app.dart';
 
 /// A base class for all FlutterFire commands.
 abstract class FlutterFireCommand extends Command<void> {
-  FlutterFireCommand(this.flutterApp);
+  FlutterFireCommand(this.flutterApp) {
+    updateDebugMode(argResults!['debug'] != null);
+  }
 
   final FlutterApp? flutterApp;
 

--- a/packages/flutterfire_cli/lib/src/commands/base.dart
+++ b/packages/flutterfire_cli/lib/src/commands/base.dart
@@ -19,16 +19,13 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
 
-import '../common/config.dart';
 import '../common/strings.dart';
 import '../common/utils.dart';
 import '../flutter_app.dart';
 
 /// A base class for all FlutterFire commands.
 abstract class FlutterFireCommand extends Command<void> {
-  FlutterFireCommand(this.flutterApp) {
-    updateDebugMode(argResults?['debug'] != null);
-  }
+  FlutterFireCommand(this.flutterApp);
 
   final FlutterApp? flutterApp;
 

--- a/packages/flutterfire_cli/lib/src/commands/base.dart
+++ b/packages/flutterfire_cli/lib/src/commands/base.dart
@@ -57,7 +57,7 @@ abstract class FlutterFireCommand extends Command<void> {
     argParser.addFlag(
       'debug',
       abbr: 'd',
-      help: 'Print verbose output.',
+      help: 'Use debug logger for additional information.',
     );
   }
 

--- a/packages/flutterfire_cli/lib/src/commands/base.dart
+++ b/packages/flutterfire_cli/lib/src/commands/base.dart
@@ -57,7 +57,7 @@ abstract class FlutterFireCommand extends Command<void> {
     argParser.addFlag(
       'debug',
       abbr: 'd',
-      help: 'Use debug logger for additional information.',
+      help: 'Use debug logger for additional output.',
     );
   }
 

--- a/packages/flutterfire_cli/lib/src/commands/base.dart
+++ b/packages/flutterfire_cli/lib/src/commands/base.dart
@@ -27,7 +27,7 @@ import '../flutter_app.dart';
 /// A base class for all FlutterFire commands.
 abstract class FlutterFireCommand extends Command<void> {
   FlutterFireCommand(this.flutterApp) {
-    updateDebugMode(argResults!['debug'] != null);
+    updateDebugMode(argResults?['debug'] != null);
   }
 
   final FlutterApp? flutterApp;
@@ -55,6 +55,12 @@ abstract class FlutterFireCommand extends Command<void> {
       valueHelp: 'email',
       abbr: 'e',
       help: 'The Google account to use for authorization.',
+    );
+
+    argParser.addFlag(
+      'debug',
+      abbr: 'd',
+      help: 'Print verbose output.',
     );
   }
 

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -563,6 +563,7 @@ class ConfigCommand extends FlutterFireCommand {
 
   @override
   Future<void> run() async {
+    // Has to set during `run()` otherwise `argResults` will be null
     updateDebugMode(argResults!['debug']as bool);
     try {
       commandRequiresFlutterApp();

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -20,6 +20,7 @@ import 'dart:io';
 import 'package:ansi_styles/ansi_styles.dart';
 import 'package:path/path.dart' as path;
 
+import '../common/global.dart';
 import '../common/inputs.dart';
 import '../common/platform.dart';
 import '../common/strings.dart';
@@ -567,6 +568,7 @@ class ConfigCommand extends FlutterFireCommand {
 
   @override
   Future<void> run() async {
+    updateDebugMode(argResults!['debug'] !=null);
     try {
       commandRequiresFlutterApp();
       final reconfigured = await checkIfUserRequiresReconfigure();

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -419,11 +419,6 @@ class ConfigCommand extends FlutterFireCommand {
         return baseMessage;
       },
     );
-    firebaseProjects = await firebase.getProjects(
-      account: accountEmail,
-      token: token,
-      serviceAccount: serviceAccount,
-    );
 
     try {
       firebaseProjects = await firebase

--- a/packages/flutterfire_cli/lib/src/commands/config.dart
+++ b/packages/flutterfire_cli/lib/src/commands/config.dart
@@ -568,7 +568,7 @@ class ConfigCommand extends FlutterFireCommand {
 
   @override
   Future<void> run() async {
-    updateDebugMode(argResults!['debug'] !=null);
+    updateDebugMode(argResults!['debug']as bool);
     try {
       commandRequiresFlutterApp();
       final reconfigured = await checkIfUserRequiresReconfigure();

--- a/packages/flutterfire_cli/lib/src/common/config.dart
+++ b/packages/flutterfire_cli/lib/src/common/config.dart
@@ -1,9 +1,11 @@
 import 'package:cli_util/cli_logging.dart';
 
-bool debugMode = false;
+bool _debugMode = false;
+
+bool get debugMode => _debugMode;
 
 void updateDebugMode(bool value) {
-  debugMode = value;
+  _debugMode = value;
 }
 
 Logger get logger => debugMode ? Logger.verbose() : Logger.standard();

--- a/packages/flutterfire_cli/lib/src/common/config.dart
+++ b/packages/flutterfire_cli/lib/src/common/config.dart
@@ -1,0 +1,9 @@
+import 'package:cli_util/cli_logging.dart';
+
+bool debugMode = false;
+
+void updateDebugMode(bool value) {
+  debugMode = value;
+}
+
+Logger get logger => debugMode ? Logger.verbose() : Logger.standard();

--- a/packages/flutterfire_cli/lib/src/common/global.dart
+++ b/packages/flutterfire_cli/lib/src/common/global.dart
@@ -5,7 +5,6 @@ bool _debugMode = false;
 bool get debugMode => _debugMode;
 
 void updateDebugMode(bool value) {
-  print('VVV: $value');
   _debugMode = value;
 }
 

--- a/packages/flutterfire_cli/lib/src/common/global.dart
+++ b/packages/flutterfire_cli/lib/src/common/global.dart
@@ -5,6 +5,7 @@ bool _debugMode = false;
 bool get debugMode => _debugMode;
 
 void updateDebugMode(bool value) {
+  print('VVV: $value');
   _debugMode = value;
 }
 

--- a/packages/flutterfire_cli/lib/src/firebase.dart
+++ b/packages/flutterfire_cli/lib/src/firebase.dart
@@ -158,7 +158,6 @@ Future<List<FirebaseProject>> getProjects({
   String? token,
   String? serviceAccount,
 }) async {
-  logger.stdout('MMMM:$debugMode');
   final response = await runFirebaseCommand(
     [
       'projects:list',

--- a/packages/flutterfire_cli/lib/src/firebase.dart
+++ b/packages/flutterfire_cli/lib/src/firebase.dart
@@ -22,7 +22,7 @@ import 'package:ansi_styles/ansi_styles.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
-import 'common/config.dart';
+import 'common/global.dart';
 import 'common/strings.dart';
 import 'common/utils.dart';
 import 'firebase/firebase_app.dart';
@@ -158,6 +158,7 @@ Future<List<FirebaseProject>> getProjects({
   String? token,
   String? serviceAccount,
 }) async {
+  logger.stdout('MMMM:$debugMode');
   final response = await runFirebaseCommand(
     [
       'projects:list',

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_project.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_project.dart
@@ -59,7 +59,9 @@ class FirebaseProject {
           name: json['name'] as String,
           state: json['state'] as String,
           resources: FirebaseProjectResources.fromJson(
-            Map<String, dynamic>.from(json['resources'] as Map),
+            Map<String, dynamic>.from(
+              json['resources'] ?? <String, dynamic>{} as Map,
+            ),
           ),
         );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

1. Fixed `resources` so it [defaults to empty object](https://github.com/invertase/flutterfire_cli/pull/329/commits/511dafcb8eba4d45eca44744d1bf619f5c9a93d2) as [confirmed by the user](https://github.com/invertase/flutterfire_cli/issues/328#issuecomment-2248211300).
2. Created global `debugMode` and `logger` which can be used in future issues to help debug issues.
3. Removed duplicate `getProjects()` [call here](https://github.com/invertase/flutterfire_cli/pull/329/commits/a1f84b4398e8af877a7ea1473c7d9ae8cd969265).
4. [Updated logic for getting firebase projects](https://github.com/invertase/flutterfire_cli/pull/329/commits/8cce13bc06dc736f2b7a1b8d020835ca18a514b0) to write to file if JSON file is huge. For users that have more than 400 projects.

fixes https://github.com/invertase/flutterfire_cli/issues/328

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
