### PR TITLE
fix: support both gradle and gradle.kts file formats #305

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -7,24 +7,24 @@ import '../common/utils.dart';
 import '../flutter_app.dart';
 import 'firebase_options.dart';
 
-// https://regex101.com/r/Lj93lx/1
+// https://regex101.com/r/Lj93lx/2
 final _androidBuildGradleRegex = RegExp(
-  r'dependencies\s*\{',
+  r'dependencies\s*[\{]',
   multiLine: true,
 );
-// https://regex101.com/r/OZnO1j/1
+// https://regex101.com/r/OZnO1j/2
 final _androidAppBuildGradleRegex = RegExp(
-  r'''(?:(^[\s]*?apply[\s]+plugin\:[\s]+['"]{1}com\.android\.application['"]{1})|(^[\s]*?id[\s]+["']com\.android\.application["']))''',
+  r'''(?:(^[\s]*?apply[\s]+plugin\:[\s]+['"]{1}com\.android\.application['"]{1})|(^[\s]*?id[\s]+["']com\.android\.application["'])|plugins\s*\{\s*id\(['"]{1}com\.android\.application['"]{1}\))''',
   multiLine: true,
 );
-// https://regex101.com/r/ndlYVL/1
+// https://regex101.com/r/ndlYVL/2
 final _androidBuildGradleGoogleServicesRegex = RegExp(
-  r'''((?<indentation>^[\s]*?)classpath\s?['"]{1}com\.google\.gms:google-services:.*?['"]{1}\s*?$)''',
+  r'''((?<indentation>^[\s]*?)(?:classpath\s?['"]{1}com\.google\.gms:google-services:.*?['"]{1}\s*?$|id\(['"]{1}com\.google\.gms\.google-services['"]{1}\)))''',
   multiLine: true,
 );
-// https://regex101.com/r/pP1k6i/1
+// https://regex101.com/r/pP1k6i/2
 final _androidAppBuildGradleGoogleServicesRegex = RegExp(
-  r'''(?:(^[\s]*?apply[\s]+plugin\:[\s]+['"]{1}com\.google\.gms\.google-services['"]{1})|(^[\s]*?id[\s]+['"]com\.google\.gms\.google-services['"]))''',
+  r'''(?:(^[\s]*?apply[\s]+plugin\:[\s]+['"]{1}com\.google\.gms\.google-services['"]{1})|(^[\s]*?id[\s]+['"]com\.google\.gms\.google-services['"])|plugins\s*\{\s*id\(['"]{1}com\.google\.gms\.google-services['"]{1}\))''',
   multiLine: true,
 );
 
@@ -57,10 +57,11 @@ String _applyGradleSettingsDependency(
   String version, {
   bool flutterfireComments = false,
 }) {
-  if (flutterfireComments) {
-    return '\n    $_flutterFireConfigCommentStart\n    id "$dependency" version "$version" apply false\n    $_flutterFireConfigCommentEnd';
-  }
-  return '\n    id "$dependency" version "$version" apply false';
+  final kotlinDslContent = flutterfireComments
+      ? '\n    $_flutterFireConfigCommentStart\n    id("$dependency") version "$version" apply false\n    $_flutterFireConfigCommentEnd'
+      : '\n    id("$dependency") version "$version" apply false';
+
+  return kotlinDslContent;
 }
 
 enum BuildGradleConfiguration {
@@ -182,9 +183,12 @@ Future<void> gradleContentUpdates(
   final androidBuildGradleFile = File(
     path.join(
       flutterApp.androidDirectory.path,
-      'build.gradle',
+      'build.gradle.kts',
     ),
-  );
+  ).existsSync()
+      ? File(path.join(flutterApp.androidDirectory.path, 'build.gradle.kts'))
+      : File(path.join(flutterApp.androidDirectory.path, 'build.gradle'));
+
   final androidBuildGradleFileContents =
       androidBuildGradleFile.readAsStringSync();
 
@@ -192,18 +196,23 @@ Future<void> gradleContentUpdates(
     path.join(
       flutterApp.androidDirectory.path,
       'app',
-      'build.gradle',
+      'build.gradle.kts',
     ),
-  );
+  ).existsSync()
+      ? File(path.join(flutterApp.androidDirectory.path, 'app', 'build.gradle.kts'))
+      : File(path.join(flutterApp.androidDirectory.path, 'app', 'build.gradle'));
+
   final androidAppBuildGradleFileContents =
       androidAppBuildGradleFile.readAsStringSync();
 
   final androidGradleSettingsFile = File(
     path.join(
       flutterApp.androidDirectory.path,
-      'settings.gradle',
+      'settings.gradle.kts',
     ),
-  );
+  ).existsSync()
+      ? File(path.join(flutterApp.androidDirectory.path, 'settings.gradle.kts'))
+      : File(path.join(flutterApp.androidDirectory.path, 'settings.gradle'));
 
   final androidGradleSettingsFileContents =
       androidGradleSettingsFile.readAsStringSync();

--- a/packages/flutterfire_cli/lib/src/flutter_app.dart
+++ b/packages/flutterfire_cli/lib/src/flutter_app.dart
@@ -123,9 +123,22 @@ class FlutterApp {
         Directory(package.path),
       ),
     );
-    if (appGradleFile.existsSync()) {
-      final fileContents = appGradleFile.readAsStringSync();
-      // Captures old and new method for setting applicationId in app/build.gradle file:
+
+    final appGradleKtsFile = File(
+      '${androidAppBuildGradlePathForAppDirectory(
+        Directory(package.path),
+      )}.kts',
+    );
+
+    String? fileContents;
+    if (appGradleKtsFile.existsSync()) {
+      fileContents = appGradleKtsFile.readAsStringSync();
+    } else if (appGradleFile.existsSync()) {
+      fileContents = appGradleFile.readAsStringSync();
+    }
+
+    if (fileContents != null) {
+      // Captures old and new method for setting applicationId in both app/build.gradle and app/build.gradle.kt file:
       // https://regex101.com/r/d9i4G6/1
       final appIdRegex = RegExp(
         r'''applicationId\s*(?:=)?\s*['"](?<applicationId>([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*)['"]''',


### PR DESCRIPTION
## Description

- Add .kts extension check in androidAppBuildGradle path
- Update regex patterns to match Kotlin DSL syntax
- Handle both file formats when reading gradle contents
- Prioritize checking .kts files before .gradle files (new projects are more likely to use .kts format)

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
