### PR TITLE
fix: add underlyingException to FirebaseJsonException when projectId or appId are missing

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -313,7 +313,10 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     }
 
     if (projectId == null || appId == null) {
-      throw FirebaseJsonException();
+      final underlyingException =
+          projectId == null ? 'projectId is missing.' : 'appId is missing.';
+
+      throw FirebaseJsonException(underlyingException: underlyingException);
     }
 
     return ConfigurationResults(

--- a/packages/flutterfire_cli/lib/src/common/strings.dart
+++ b/packages/flutterfire_cli/lib/src/common/strings.dart
@@ -136,7 +136,7 @@ class FirebaseJsonException implements FlutterFireException {
   final String? underlyingException;
   @override
   String toString() {
-    return 'FirebaseJsonException: Please run "flutterfire configure" to update the `firebase.json` at the root of your Flutter project with correct values. ${underlyingException != null ? '' : underlyingException}';
+    return 'FirebaseJsonException: Please run "flutterfire configure" to update the `firebase.json` at the root of your Flutter project with correct values. ${underlyingException ?? ''}';
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This is a follow up to #354. It improves the error message for misconfigured `firebase.json` file.

<!--- Describe your changes in detail -->

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
