### PR TITLE
fix: Relax android package name validation

### DIFF
--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -524,7 +524,7 @@ void validateAppBundleId(
 
 void validateAndroidPackageName(String appId) {
   final appIdRegex = RegExp(
-    r'^[a-zA-Z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)+$',
+    r'^[a-zA-Z][a-zA-Z0-9]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$',
   );
 
   if (!appIdRegex.hasMatch(appId)) {

--- a/packages/flutterfire_cli/test/unit_test.dart
+++ b/packages/flutterfire_cli/test/unit_test.dart
@@ -112,6 +112,10 @@ void main() {
         () => validateAndroidPackageName('com.example123.app456'),
         returnsNormally,
       );
+      expect(
+        () => validateAndroidPackageName('abc123.com.example.app'),
+        returnsNormally,
+      );
     });
 
     test('Invalid Package names', () {


### PR DESCRIPTION
Fixes #368 

## Description

Relax conditions for android package name validations

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
