### PR TITLE
fix: Check for `Pods/FirebaseCrashlytics` directory when using SPM

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -392,7 +392,7 @@ bashScript = %q(
 #!/bin/bash
 PATH="\${PATH}:\$FLUTTER_ROOT/bin:\$HOME/.pub-cache/bin"
 
-if [ -z "$PODS_ROOT" ] || [ ! -d "$PODS_ROOT/FirebaseCrashlytics" ]; then
+if [ -z "\$PODS_ROOT" ] || [ ! -d "\$PODS_ROOT/FirebaseCrashlytics" ]; then
   # Cannot use "BUILD_DIR%/Build/*" as per Firebase documentation, it points to "flutter-project/build/ios/*" path which doesn't have run script
   DERIVED_DATA_PATH=\$(echo "\$BUILD_ROOT" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')
   PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -392,7 +392,7 @@ bashScript = %q(
 #!/bin/bash
 PATH="\${PATH}:\$FLUTTER_ROOT/bin:\$HOME/.pub-cache/bin"
 
-if [ -z "\$PODS_ROOT" ]; then
+if [ -z "$PODS_ROOT" ] || [ ! -d "$PODS_ROOT/FirebaseCrashlytics" ]; then
   # Cannot use "BUILD_DIR%/Build/*" as per Firebase documentation, it points to "flutter-project/build/ios/*" path which doesn't have run script
   DERIVED_DATA_PATH=\$(echo "\$BUILD_ROOT" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')
   PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"


### PR DESCRIPTION
…Pods simultaneously

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

If using pods and SPM packages simultaneously the Pods folder still exists, but the script is in the SPM directory.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
