### PR TITLE
fix: firebase_core folder order by parsing the version

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -2,9 +2,10 @@ import 'dart:io';
 
 import 'package:cli_util/cli_logging.dart';
 import 'package:collection/collection.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
+
 import '../common/strings.dart';
 import '../common/utils.dart';
 import '../flutter_app.dart';
@@ -1125,7 +1126,6 @@ Future<FirebasePubSpecModel> getFirebaseCorePubSpec() async {
     );
 
     final firebaseCoreDirectory = firebaseCoreItems.last;
-    print(firebaseCoreDirectory);
 
     final firebaseCorePubspecFile =
         pubspecPathForDirectory(firebaseCoreDirectory);

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -1110,15 +1110,30 @@ Future<FirebasePubSpecModel> getFirebaseCorePubSpec() async {
     final pubCacheFolder = _getPubCacheDirectory();
     final items = pubCacheFolder.listSync();
     final firebaseCoreItems = items
+        // Take only folders
         .whereType<Directory>()
-        .where((e) => e.path.split('/').last.startsWith(packageName))
+        // Take only folders from firebase_core package
+        .where(
+          (e) => e.uri.pathSegments
+              .where((p) => p.isNotEmpty)
+              .last
+              .startsWith(packageName),
+        )
+        // Sort by version
         .sorted(
       (a, b) {
         final aVersion = Version.parse(
-          a.path.split('/').last.replaceFirst(packageName, ''),
+          a.uri.pathSegments
+              .where((p) => p.isNotEmpty)
+              .last
+              .replaceFirst(packageName, ''),
         );
+
         final bVersion = Version.parse(
-          b.path.split('/').last.replaceFirst(packageName, ''),
+          b.uri.pathSegments
+              .where((p) => p.isNotEmpty)
+              .last
+              .replaceFirst(packageName, ''),
         );
 
         return aVersion.compareTo(bVersion);
@@ -1126,7 +1141,6 @@ Future<FirebasePubSpecModel> getFirebaseCorePubSpec() async {
     );
 
     final firebaseCoreDirectory = firebaseCoreItems.last;
-
     final firebaseCorePubspecFile =
         pubspecPathForDirectory(firebaseCoreDirectory);
     final content = await File(firebaseCorePubspecFile).readAsString();

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cli_util/cli_logging.dart';
 import 'package:collection/collection.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 import '../common/strings.dart';
@@ -1104,13 +1105,27 @@ AndroidGradleContents _applyFirebaseAndroidPluginKts({
 
 Future<FirebasePubSpecModel> getFirebaseCorePubSpec() async {
   try {
+    const packageName = 'firebase_core-';
     final pubCacheFolder = _getPubCacheDirectory();
     final items = pubCacheFolder.listSync();
-    final firebaseCoreDirectory = items
+    final firebaseCoreItems = items
         .whereType<Directory>()
-        .where((e) => e.path.split('/').last.startsWith('firebase_core-'))
-        .sortedBy((d) => d.path)
-        .last;
+        .where((e) => e.path.split('/').last.startsWith(packageName))
+        .sorted(
+      (a, b) {
+        final aVersion = Version.parse(
+          a.path.split('/').last.replaceFirst(packageName, ''),
+        );
+        final bVersion = Version.parse(
+          b.path.split('/').last.replaceFirst(packageName, ''),
+        );
+
+        return aVersion.compareTo(bVersion);
+      },
+    );
+
+    final firebaseCoreDirectory = firebaseCoreItems.last;
+    print(firebaseCoreDirectory);
 
     final firebaseCorePubspecFile =
         pubspecPathForDirectory(firebaseCoreDirectory);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,5 @@ dev_dependencies:
 dependency_overrides:
   flutterfire_cli:
     path: ./packages/flutterfire_cli
+dependencies:
+  pub_semver: ^2.2.0


### PR DESCRIPTION
## Description

There was an issue where folder ordering by name would think firebase_core-3.3.0 was higher than firebase_core-3.14.0. I used pub_semver to parse the version to make sure we get the latest version. It might look redundant, but I decided to filter out other package folders to make sure we don't parse the version of all the pub cache folders.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
