### PR TITLE
fix: Attempt to run the Firebase CLI via npx if it's not installed

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase.dart
+++ b/packages/flutterfire_cli/lib/src/firebase.dart
@@ -87,7 +87,8 @@ Future<Map<String, dynamic>> runFirebaseCommand(
       String? serviceAccount,
     }) async {
   final workingDirectoryPath = Directory.current.path;
-  final execArgs = [
+  var command = 'firebase';
+  var execArgs = [
     ...commandAndArgs,
     '--json',
     if (project != null) '--project=$project',
@@ -105,26 +106,17 @@ Future<Map<String, dynamic>> runFirebaseCommand(
         logMissingFirebaseCli,
       );
     }
-    final npxExecArgs = [
+    command = 'npx'
+    execArgs = [
       'firebase-tools@latest'
       ...execArgs,
     ];
-    process = await Process.run(
-      'npx',
-      npxExecArgs,
-      workingDirectory: workingDirectoryPath,
-      environment: {
-        if (serviceAccount != null)
-          'GOOGLE_APPLICATION_CREDENTIALS': serviceAccount,
-      },
-      runInShell: true,
-    );
   }
 
   ProcessResult process;
   try {
     process = await Process.run(
-      'firebase',
+      command,
       execArgs,
       workingDirectory: workingDirectoryPath,
       environment: {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When you run the flutterfire_cli via the Gemini CLI, we're running into users that don't have the Firebase CLI installed. Because the Firebase MCP server runs via npx, users don't install the Firebase CLI to their PATH.

To ensure compatibility, we're suggesting that we run the Firebase CLI via npx as a backup if it doesn't exist.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
