### PR TITLE
chore: format generated firebase.json for readability

### DIFF
--- a/packages/flutterfire_cli/lib/src/common/utils.dart
+++ b/packages/flutterfire_cli/lib/src/common/utils.dart
@@ -337,13 +337,13 @@ Future<void> writeFirebaseJsonFile(
       ..._generateFlutterMap(),
     };
 
-    final mapJson = json.encode(updatedMap);
+    final mapJson = const JsonEncoder.withIndent('  ').convert(updatedMap);
 
     file.writeAsStringSync(mapJson);
   } else {
     final map = _generateFlutterMap();
 
-    final mapJson = json.encode(map);
+    final mapJson = const JsonEncoder.withIndent('  ').convert(map);
 
     file.writeAsStringSync(mapJson);
   }
@@ -403,7 +403,7 @@ Future<void> writeToFirebaseJson({
     }
   }
 
-  final mapJson = json.encode(decodedMap);
+  final mapJson = const JsonEncoder.withIndent('  ').convert(decodedMap);
 
   file.writeAsStringSync(mapJson);
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Running `flutterfire configure` generates a `firebase.json` like
```json
{"firestore":{"database":"(default)","location":"nam5","rules":"firestore.rules","indexes":"firestore.indexes.json"},"flutter":{"platforms":{"dart":{"lib/firebase_options.dart":{"projectId":"PROJECT_ID","configurations":{"web":"APP_ID"}}}}}}
```

Add formatting to the generated `firebase.json` output when running `flutterfire configure`.
```json
{
  "firestore": {
    "database": "(default)",
    "location": "nam5",
    "rules": "firestore.rules",
    "indexes": "firestore.indexes.json"
  },
  "flutter": {
    "platforms": {
      "dart": {
        "lib/firebase_options.dart": {
          "projectId": "PROJECT_ID",
          "configurations": {
            "web": "APP_ID"
          }
        }
      }
    }
  }
}
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [X] 🗑️ `chore` -- Chore


note: it doesn't seem like `writeFirebaseJsonFile` is used anywhere, but updating it anyway. in case we'd prefer this to be removed, just let me know