### PR TITLE
fix: plugin selection on terminal during choices prompt

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/install.dart
+++ b/packages/flutterfire_cli/lib/src/commands/install.dart
@@ -144,15 +144,15 @@ class InstallCommand extends FlutterFireCommand {
         .where(
           (element) => listAvailablePluginsInVersion.contains(element.name),
         )
-        .map((plugin) => plugin.displayName)
         .toList();
+    final displayNames = choices.map((plugin) => plugin.displayName).toList();
     final defaultSelection = List<bool>.filled(choices.length, false);
     for (final dependency in flutterApp!.package.dependencies) {
-      final enumValue = FlutterFirePlugins.values.firstWhereOrNull(
+      final enumValue = choices.firstWhereOrNull(
         (element) => element.name == dependency,
       );
       if (enumValue != null) {
-        final index = choices.indexOf(enumValue.displayName);
+        final index = choices.indexOf(enumValue);
         defaultSelection[index] = true;
       }
     }
@@ -161,11 +161,12 @@ class InstallCommand extends FlutterFireCommand {
 
     final selectedChoices = promptMultiSelect(
       'Select the Firebase plugins you would like to install',
-      choices,
+      displayNames,
       defaultSelection: defaultSelection,
     );
     for (final index in selectedChoices) {
-      selectedPlugins.add(FlutterFirePlugins.values[index]);
+      // retrieve plugin based on the choices list
+      selectedPlugins.add(choices[index]);
     }
     return selectedPlugins;
   }

--- a/packages/flutterfire_cli/test/install_test.dart
+++ b/packages/flutterfire_cli/test/install_test.dart
@@ -1,10 +1,20 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
+
+Future<bool> _waitForLine(StreamQueue<String> queue, String content) async {
+  while (await queue.hasNext) {
+    final line = await queue.next;
+    if (line.contains(content)) return true;
+  }
+  return false;
+}
 
 void main() {
   String? projectPath;
@@ -131,7 +141,6 @@ void main() {
       Duration(minutes: 2),
     ),
   );
-
   test(
     'Installs then use --only-pubspec-plugins flag to remove dependency',
     () async {
@@ -184,6 +193,90 @@ void main() {
       expect(parsedPubspec2.dependencies['cloud_firestore'], isNull);
 
       expect(result.stdout.toString().contains('Successfully installed'), true);
+    },
+    timeout: const Timeout(
+      Duration(minutes: 2),
+    ),
+  );
+  test(
+    'Installs from CLI',
+    () async {
+      final process = await Process.start(
+        'flutterfire',
+        [
+          'install',
+          '4.10.0',
+        ],
+        workingDirectory: projectPath,
+        runInShell: true,
+      );
+      final stdoutLines = StreamQueue(
+        process.stdout
+            .transform(utf8.decoder) /*.transform(const LineSplitter())*/,
+      );
+
+      await _waitForLine(
+        stdoutLines,
+        'Select the Firebase plugins you would like to install',
+      );
+
+      // Core
+      process.stdin.write(' ');
+
+      // Analytics
+      process.stdin.write('\x1b[B');
+      process.stdin.write(' ');
+
+      // Crashlytics
+      process.stdin.write('\x1b[B' * 4);
+      process.stdin.write(' ');
+
+      // Messaging
+      process.stdin.write('\x1b[B' * 5);
+      process.stdin.write(' ');
+
+      // Performance
+      process.stdin.write('\x1b[B' * 2);
+      process.stdin.write(' ');
+
+      // Remote Config
+      process.stdin.write('\x1b[B');
+      process.stdin.write(' ');
+
+      // confirm selection
+      process.stdin.write('\r');
+
+      await process.stdin.flush();
+
+      final installSuccess =
+          await _waitForLine(stdoutLines, 'Successfully installed');
+      expect(installSuccess, isTrue);
+
+      // finish
+      await process.stdin.flush();
+      await process.stdin.close();
+
+      if (await process.exitCode != 0) {
+        final errorOutput = await process.stderr.transform(utf8.decoder).join();
+        fail(errorOutput);
+      }
+
+      final parsedPubspec = Pubspec.parse(
+        await File(p.join(projectPath!, 'pubspec.yaml')).readAsString(),
+      );
+
+      expect(parsedPubspec.dependencies['firebase_analytics'], isNotNull);
+      expect(parsedPubspec.dependencies['firebase_core'], isNotNull);
+      expect(parsedPubspec.dependencies['firebase_performance'], isNotNull);
+      expect(parsedPubspec.dependencies['firebase_remote_config'], isNotNull);
+      expect(parsedPubspec.dependencies['firebase_crashlytics'], isNotNull);
+      expect(parsedPubspec.dependencies['firebase_messaging'], isNotNull);
+
+      expect(parsedPubspec.dependencies['firebase_in_app_messaging'], isNull);
+      expect(
+        parsedPubspec.dependencies['firebase_ml_model_downloader'],
+        isNull,
+      );
     },
     timeout: const Timeout(
       Duration(minutes: 2),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This change fixes the selection mismatch when it is launched via `flutterfire install <version>` vs `flutterfire install --version=<version> --plugins=<plugins>`

For purposes of testing, I was using `flutterfire install 4.10.0` with the selecion of the plugins:` firebase_core, firebase_analytics, firebase_messaging, firebase_performance, firebase_remote_config, firebase_crashlytics`.

The current terminal logic ends by installing the following packages `firebase_in_app_messaging, firebase_ml_model_downloader` instead of `firebase_messaging, firebase_remote_config`.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
