### PR TITLE
fix: handle null configurations key in reconfigure dart config

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
+++ b/packages/flutterfire_cli/lib/src/commands/reconfigure.dart
@@ -266,7 +266,8 @@ class Reconfigure extends FlutterFireCommand {
         dartConfig.entries.map<Future<List<ConfigFileWrite>>>((entry) {
       final path = entry.key;
       final map = entry.value as Map<String, dynamic>;
-      final configurations = map[kConfigurations] as Map<String, dynamic>;
+      final configurations = map[kConfigurations] as Map<String, dynamic>?;
+      if (configurations == null) return Future.value([]);
       final projectId = map[kProjectId] as String;
 
       final configWrite = ConfigFileWrite(


### PR DESCRIPTION
Fixes #353

## Problem
When running `flutterfire configure` twice and choosing to reuse the 
existing `firebase.json`, the command crashes with:

Exception: type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast

This happens in `_writeDartConfigurationFile` in `reconfigure.dart` 
where `map[kConfigurations]` is cast directly without a null check. 
If the existing `firebase.json` was written by an older CLI version 
that didn't include the `configurations` key, the cast throws.

## Fix
Cast `map[kConfigurations]` as nullable `Map<String, dynamic>?` and 
return early if null, skipping that entry gracefully.