### PR TITLE
fix: add newline at end of firebase_options.dart

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
@@ -184,7 +184,7 @@ class FirebaseDartConfigurationWrite {
     _stringBuffer.clear();
     _writeHeader();
     _writeClass();
-    return '${formatList(_stringBuffer.toString().split('\n')).join('\n')}\n';
+    return formatList(_stringBuffer.toString().split('\n')).join('\n');
   }
 
   // ensure only one empty line between each static property

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
@@ -177,14 +177,14 @@ class FirebaseDartConfigurationWrite {
       }
     }
 
-    return formatList(fileConfigurationLines).join('\n');
+    return '${formatList(fileConfigurationLines).join('\n')}\n';
   }
 
   String _buildConfigurationFile() {
     _stringBuffer.clear();
     _writeHeader();
     _writeClass();
-    return formatList(_stringBuffer.toString().split('\n')).join('\n');
+    return '${formatList(_stringBuffer.toString().split('\n')).join('\n')}\n';
   }
 
   // ensure only one empty line between each static property


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

flutterfire configure generates firebase_options.dart
without a newline at the end of the file.

This causes dart format to modify the generated file 
every time it is run, resulting in:
- Unnecessary changes in git diff
- CI/CD pipeline failures when dart format check is enabled
- Confusion for developers seeing unexpected file changes

##How I Found It

Searched for writeAsStringSync across the codebase to 
find where firebase_options.dart content is written.

This led to:
packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart

Inside this file, two functions build and return the 
content of firebase_options.dart as a string using 
.join('\n') — which joins lines with newlines BETWEEN 
them but does NOT add a newline at the END of the file.

##What I Changed

File: 
packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart

**Line 180** — inside `_updateExistingConfigurationFile()`:
```dart
// Before ❌
return formatList(fileConfigurationLines).join('\n');

// After ✅
return '${formatList(fileConfigurationLines).join('\n')}\n';
```

**Line 187** — inside `_buildConfigurationFile()`:
```dart
// Before ❌
return formatList(_stringBuffer.toString().split('\n')).join('\n');

// After ✅
return '${formatList(_stringBuffer.toString().split('\n')).join('\n')}\n';
```

The \n appended at the end ensures the generated 
`firebase_options.dart` always ends with a newline, 
satisfying dart format requirements.



<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
