### PR TITLE
fix: windows flutter.bat compatibility for update command

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/update.dart
+++ b/packages/flutterfire_cli/lib/src/commands/update.dart
@@ -102,7 +102,7 @@ class UpdateCommand extends FlutterFireCommand {
 
     logger.stdout("Running 'flutter pub get'...");
     await Process.run(
-      flutterCmd, //  reused flutterCmd again!
+      flutterCmd,
       ['pub', 'get'],
     );
 

--- a/packages/flutterfire_cli/lib/src/commands/update.dart
+++ b/packages/flutterfire_cli/lib/src/commands/update.dart
@@ -76,28 +76,33 @@ class UpdateCommand extends FlutterFireCommand {
     commandRequiresFlutterApp();
 
     logger.stdout('Cleaning up current workspace ...');
+    final flutterCmd = Platform.isWindows ? 'flutter.bat' : 'flutter';
     await Process.run(
-      'flutter',
+      flutterCmd,
       ['clean'],
     );
-    await Process.run(
-      'rm',
-      ['pubspec.lock'],
-    );
+    if (Platform.isWindows) {
+      await File('pubspec.lock').delete();
+    } else {
+      await Process.run(
+        'rm',
+        ['pubspec.lock'],
+      );
+    }
 
     logger.stdout('Upgrading all firebase plugins to the latest version ...');
     for (final package in flutterfirePackages) {
       // We run each package individually because chaining them
       // will fail at the first package not in the pubspec.
       await Process.run(
-        'flutter',
+        flutterCmd, //  reusing the flutterCmd variable which already made on line 79!
         ['pub', 'upgrade', '--major-versions', package],
       );
     }
 
     logger.stdout("Running 'flutter pub get'...");
     await Process.run(
-      'flutter',
+      flutterCmd, //  reused flutterCmd again!
       ['pub', 'get'],
     );
 

--- a/packages/flutterfire_cli/lib/src/commands/update.dart
+++ b/packages/flutterfire_cli/lib/src/commands/update.dart
@@ -81,13 +81,9 @@ class UpdateCommand extends FlutterFireCommand {
       flutterCmd,
       ['clean'],
     );
-    if (Platform.isWindows) {
-      await File('pubspec.lock').delete();
-    } else {
-      await Process.run(
-        'rm',
-        ['pubspec.lock'],
-      );
+    final pubspecLockFile = File('pubspec.lock');
+    if (pubspecLockFile.existsSync()) {
+      await pubspecLockFile.delete();
     }
 
     logger.stdout('Upgrading all firebase plugins to the latest version ...');

--- a/packages/flutterfire_cli/lib/src/commands/update.dart
+++ b/packages/flutterfire_cli/lib/src/commands/update.dart
@@ -95,7 +95,7 @@ class UpdateCommand extends FlutterFireCommand {
       // We run each package individually because chaining them
       // will fail at the first package not in the pubspec.
       await Process.run(
-        flutterCmd, //  reusing the flutterCmd variable which already made on line 79!
+        flutterCmd,
         ['pub', 'upgrade', '--major-versions', package],
       );
     }

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_dart_configuration_write.dart
@@ -177,14 +177,14 @@ class FirebaseDartConfigurationWrite {
       }
     }
 
-    return formatList(fileConfigurationLines).join('\n');
+    return '${formatList(fileConfigurationLines).join('\n')}\n';
   }
 
   String _buildConfigurationFile() {
     _stringBuffer.clear();
     _writeHeader();
     _writeClass();
-    return formatList(_stringBuffer.toString().split('\n')).join('\n');
+    return '${formatList(_stringBuffer.toString().split('\n')).join('\n')}\n';
   }
 
   // ensure only one empty line between each static property


### PR DESCRIPTION

## Description

`flutterfire update` crashes on Windows with `ProcessException: System cannot find the specified file` because the update command uses Linux/Mac-only commands.

**Two bugs found in `update.dart`:**
1. `flutter` command needs to be `flutter.bat` on Windows
2. `rm` command does not exist on Windows

## How I Found It
Searched issue #252 where users reported `flutterfire update` crashing on Windows. The stack trace pointed directly to `update.dart` line 79 where `Process.run('flutter', ...)` fails because Windows requires the `.bat` extension.

User `jibbers42` also identified the exact lines in the issue comments.

## What I Changed
File: `packages/flutterfire_cli/lib/src/commands/update.dart`

**Fix 1 — flutter.bat on Windows:**
```dart
// Before 
await Process.run('flutter', ['clean']);

// After 
final flutterCmd = Platform.isWindows ? 'flutter.bat' : 'flutter';
await Process.run(flutterCmd, ['clean']);
```

**Fix 2 — Cross-platform file deletion:**

Initial fix used `if/else Platform.isWindows` to handle `rm` not existing on Windows.

After Gemini code review suggested a simpler approach, updated to use Dart's built-in `File` API which works across all platforms:

```dart
// Before 
await Process.run('rm', ['pubspec.lock']);

// After 
final pubspecLockFile = File('pubspec.lock');
if (pubspecLockFile.existsSync()) {
  await pubspecLockFile.delete();
}
```

`flutterCmd` is reused for all 3 `flutter` command calls in the file.

Fixes #252 

## Type of change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
