### PR TITLE
docs(repo): update code of conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-- [Code of Conduct](https://github.com/invertase/meta/blob/master/CODE_OF_CONDUCT.md)
+- [Code of Conduct](https://github.com/invertase/.github/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Summary
- update the repository code of conduct link to point at the shared `invertase/.github` location
- remove the stale dependency on the old `invertase/meta` path

## Test plan
- [ ] Docs-only change