### PR TITLE
fix(crashlytics): resolve SPM run script for Flutter 3.44+ and custom -derivedDataPath

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -399,12 +399,47 @@ bashScript = %q(
 #!/bin/bash
 PATH="\${PATH}:\$FLUTTER_ROOT/bin:\${PUB_CACHE}/bin:\$HOME/.pub-cache/bin"
 
-if [ -z "\$PODS_ROOT" ] || [ ! -d "\$PODS_ROOT/FirebaseCrashlytics" ]; then
-  # Cannot use "BUILD_DIR%/Build/*" as per Firebase documentation, it points to "flutter-project/build/ios/*" path which doesn't have run script
-  DERIVED_DATA_PATH=\$(echo "\$BUILD_ROOT" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')
-  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
-else
+# Locate the firebase-ios-sdk Crashlytics 'run' script.
+#
+# CocoaPods:  \$PODS_ROOT/FirebaseCrashlytics/run
+# SPM:        <derivedDataPath>/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
+#
+# The derived-data root depends on how Xcode was invoked:
+#   * flutter build ios       -> <flutter project>/build/ios
+#   * Xcode standalone build  -> ~/Library/Developer/Xcode/DerivedData/Runner-XXXXX
+#   * xcodebuild -derivedDataPath <custom> (e.g. fastlane gym) -> <custom>
+#
+# In every case BUILD_DIR has the shape <derivedDataPath>/Build/..., so
+# stripping "/Build/..." from BUILD_DIR (or BUILT_PRODUCTS_DIR / BUILD_ROOT
+# as fallbacks) reliably yields the derived-data root.
+resolve_spm_run_script() {
+  local source="\$1"
+  [ -z "\$source" ] && return 1
+  local root
+  root=\$(printf '%s' "\$source" | sed -E 's|/Build/.*||')
+  local candidate="\${root}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+  if [ -f "\$candidate" ]; then
+    echo "\$candidate"
+    return 0
+  fi
+  return 1
+}
+
+if [ -n "\$PODS_ROOT" ] && [ -d "\$PODS_ROOT/FirebaseCrashlytics" ]; then
   PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$PODS_ROOT/FirebaseCrashlytics/run"
+else
+  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\$(resolve_spm_run_script "\$BUILD_DIR")
+  if [ -z "\$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
+    PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\$(resolve_spm_run_script "\$BUILT_PRODUCTS_DIR")
+  fi
+  if [ -z "\$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
+    PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\$(resolve_spm_run_script "\$BUILD_ROOT")
+  fi
+fi
+
+if [ -z "\$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ] || [ ! -f "\$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
+  echo "warning: Crashlytics 'run' script not found; skipping symbol upload"
+  exit 0
 fi
 
 # Command to upload symbols script used to upload symbols to Firebase server


### PR DESCRIPTION
## Description

Fixes #443.

`flutterfire configure` injects an Xcode Run Script Build Phase that spawns `firebase-ios-sdk/Crashlytics/run` to upload dSYMs. With Swift Package Manager the binary lives at `<derivedDataPath>/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`, but the previous implementation hardcoded a regex that only matches Xcode's standalone DerivedData layout:

```bash
DERIVED_DATA_PATH=$(echo "$BUILD_ROOT" | sed -E 's|(.*DerivedData/[^/]+).*|\1|')
```

This breaks two real-world layouts:

1. **Flutter 3.44+ project-local builds** (`flutter build ios`) place SourcePackages under `<project>/build/ios/SourcePackages/...`, which contains no `DerivedData/` segment — sed leaves `BUILD_ROOT` untouched and the spawned path doesn't exist (`ProcessException: No such file or directory`).
2. **`xcodebuild -derivedDataPath <custom>`** runs (e.g. `fastlane gym` with its per-run isolation directory) place SourcePackages under `<custom>/SourcePackages/...`, again no `DerivedData/` segment.

## Fix

Replace the regex with a `resolve_spm_run_script` helper that strips `/Build/...` from `BUILD_DIR` (then `BUILT_PRODUCTS_DIR` / `BUILD_ROOT` as fallbacks) to recover the derived-data root. Xcode build settings guarantee `BUILD_DIR` has the shape `<derivedDataPath>/Build/...` across all three layouts (Xcode standalone, Flutter project-local, custom -derivedDataPath), so the strip-based anchor is reliable everywhere the previous regex was, plus the two cases it missed.

Also fall back to `exit 0` with a warning if no candidate `run` file exists, so a misconfigured project surfaces a clear message instead of killing the archive with `ProcessException`.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore

## Test plan

The existing integration test `Validate flutterfire upload-crashlytics-symbols script is ran when building app` (test/configure_test.dart:585) exercises the new resolver end-to-end via `flutter build ios --simulator --debug` after switching the project to SPM. On Flutter 3.44, that test reproduces #443 with the old regex (`flutter build` outputs to `build/ios`, not `~/Library/.../DerivedData/Runner-X`) and passes with this fix.

Verified manually against all three layouts:

- [x] Xcode standalone build (`~/Library/Developer/Xcode/DerivedData/Runner-XXXXX`)
- [x] `flutter build ios` Flutter 3.44.0 (`<project>/build/ios/SourcePackages/...`)
- [x] `xcodebuild -derivedDataPath` custom (fastlane gym per-run dir)

## Allow edits by maintainers

- [x] Edits from maintainers allowed.