### PR TITLE
fix: macOS CI - locate Crashlytics upload-symbols script under Flutter's SPM checkout path

### DIFF
--- a/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
+++ b/packages/flutterfire_cli/lib/src/commands/upload_symbols.dart
@@ -364,6 +364,16 @@ class UploadCrashlyticsSymbols extends FlutterFireCommand {
     final buildConfiguration =
         buildDirectory.existsSync() ? 'Release' : 'Debug';
 
+    if (!File(uploadSymbolsScriptPath).existsSync()) {
+      throw Exception(
+        'Could not find the Crashlytics upload symbols script at '
+        '"$uploadSymbolsScriptPath". This usually means CocoaPods or Swift '
+        'Package Manager has not finished installing "FirebaseCrashlytics" '
+        'yet, or it was installed to an unexpected location. Try cleaning '
+        'and rebuilding the project.',
+      );
+    }
+
     // Validation script
     final validationScript = await Process.run(
       uploadSymbolsScriptPath,

--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -399,12 +399,29 @@ bashScript = %q(
 #!/bin/bash
 PATH="\${PATH}:\$FLUTTER_ROOT/bin:\${PUB_CACHE}/bin:\$HOME/.pub-cache/bin"
 
-if [ -z "\$PODS_ROOT" ] || [ ! -d "\$PODS_ROOT/FirebaseCrashlytics" ]; then
+if [ -n "\$PODS_ROOT" ] && [ -f "\$PODS_ROOT/FirebaseCrashlytics/run" ]; then
+  # CocoaPods installation.
+  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$PODS_ROOT/FirebaseCrashlytics/run"
+elif [ -n "\$BUILD_DIR" ] && [ -f "\$BUILD_DIR/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" ]; then
+  # Swift Package Manager installation. Flutter resolves Swift Package Manager
+  # checkouts into "\$BUILD_DIR/SourcePackages" (i.e. "<project>/[ios|macos]/build/SourcePackages"),
+  # rather than the Xcode DerivedData directory used for a plain Xcode project.
+  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$BUILD_DIR/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+else
+  # Fall back to the Xcode DerivedData directory in case Swift Package Manager
+  # checkouts are not resolved relative to "\$BUILD_DIR" (older/alternative setups).
   # Cannot use "BUILD_DIR%/Build/*" as per Firebase documentation, it points to "flutter-project/build/ios/*" path which doesn't have run script
   DERIVED_DATA_PATH=\$(echo "\$BUILD_ROOT" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')
   PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
-else
-  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$PODS_ROOT/FirebaseCrashlytics/run"
+
+  if [ ! -f "\$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT" ]; then
+    # Last resort: search both known Swift Package Manager checkout roots in case
+    # the exact expected layout above does not match this Xcode/Flutter version.
+    FOUND_UPLOAD_SCRIPT=\$(find "\$BUILD_DIR" "\${DERIVED_DATA_PATH}" -type f -path '*firebase-ios-sdk/Crashlytics/run' -print -quit 2>/dev/null)
+    if [ -n "\$FOUND_UPLOAD_SCRIPT" ]; then
+      PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$FOUND_UPLOAD_SCRIPT"
+    fi
+  fi
 fi
 
 # Command to upload symbols script used to upload symbols to Firebase server

--- a/packages/flutterfire_cli/test/configure_test.dart
+++ b/packages/flutterfire_cli/test/configure_test.dart
@@ -645,7 +645,9 @@ void main() {
       );
 
       if (buildApp.exitCode != 0) {
-        fail(buildApp.stderr as String);
+        fail(
+          'stdout:\n${buildApp.stdout}\n\nstderr:\n${buildApp.stderr}',
+        );
       }
 
       expect(
@@ -686,7 +688,9 @@ void main() {
       );
 
       if (buildAppSPM.exitCode != 0) {
-        fail(buildAppSPM.stderr as String);
+        fail(
+          'stdout:\n${buildAppSPM.stdout}\n\nstderr:\n${buildAppSPM.stderr}',
+        );
       }
 
       expect(
@@ -1685,7 +1689,9 @@ void main() {
       );
 
       if (buildApp.exitCode != 0) {
-        fail(buildApp.stderr as String);
+        fail(
+          'stdout:\n${buildApp.stdout}\n\nstderr:\n${buildApp.stderr}',
+        );
       }
 
       expect(
@@ -1726,7 +1732,9 @@ void main() {
       );
 
       if (buildAppSPM.exitCode != 0) {
-        fail(buildAppSPM.stderr as String);
+        fail(
+          'stdout:\n${buildAppSPM.stdout}\n\nstderr:\n${buildAppSPM.stderr}',
+        );
       }
 
       expect(


### PR DESCRIPTION
## Problem

`test_macos` in CI (`test.yaml`) has been failing consistently for months on the \`Validate \`flutterfire upload-crashlytics-symbols\` script is ran when building app\` and \`Validate dev dependency works as normal & ...\` tests in `configure_test.dart`, while `test_linux` and `test_windows` passed.

## Root cause

The generated Xcode "Run Script" build phase for `flutterfire upload-crashlytics-symbols` locates Firebase's `Crashlytics/run` script by:
- Using `$PODS_ROOT/FirebaseCrashlytics/run` for CocoaPods, or
- Deriving a path from `$BUILD_ROOT`'s Xcode DerivedData folder for Swift Package Manager (SPM): `~/Library/Developer/Xcode/DerivedData/<hash>/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`.

Flutter's current stable tooling resolves SPM package checkouts into the project's own build directory instead: `$BUILD_DIR/SourcePackages/checkouts/...` (confirmed from the actual `-I` compiler include paths in a verbose CI build log). The DerivedData-based path therefore doesn't exist on CI, causing:

```
Unhandled exception:
ProcessException: No such file or directory
  Command: .../DerivedData/Runner-xxxx/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
```

This didn't reproduce locally because this machine's Flutter version still places SPM checkouts under DerivedData, which is exactly why this has been so hard for the existing DerivedData-only fallback to catch.

## Fix

- `firebase_apple_writes.dart`: check, in order, `$PODS_ROOT/FirebaseCrashlytics/run` (CocoaPods) → `$BUILD_DIR/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run` (current Flutter SPM default) → legacy DerivedData-based path, with a `find` across both roots as a last resort.
- `upload_symbols.dart`: throw a clear, actionable error if the resolved script still doesn't exist, instead of a cryptic `ProcessException`.
- `configure_test.dart`: surface full `stdout` (not just `stderr`) on build failures so future regressions are easier to diagnose from CI logs alone.

## Verification

Ran `test.yaml` via `workflow_dispatch` on this branch twice:
- Before this fix (diagnostic-only commit): macOS job failed with the real error captured above.
- After the fix: all jobs green, including the two previously-failing Crashlytics tests — https://github.com/invertase/flutterfire_cli/actions/runs/30440849782