### PR TITLE
fix: Update path to dsym upload script in projects with SPM

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_apple_writes.dart
@@ -402,11 +402,11 @@ PATH="\${PATH}:\$FLUTTER_ROOT/bin:\${PUB_CACHE}/bin:\$HOME/.pub-cache/bin"
 if [ -n "\$PODS_ROOT" ] && [ -f "\$PODS_ROOT/FirebaseCrashlytics/run" ]; then
   # CocoaPods installation.
   PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$PODS_ROOT/FirebaseCrashlytics/run"
-elif [ -n "\$BUILD_DIR" ] && [ -f "\$BUILD_DIR/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" ]; then
-  # Swift Package Manager installation. Flutter resolves Swift Package Manager
-  # checkouts into "\$BUILD_DIR/SourcePackages" (i.e. "<project>/[ios|macos]/build/SourcePackages"),
-  # rather than the Xcode DerivedData directory used for a plain Xcode project.
-  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\$BUILD_DIR/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+elif [ -f "\${SRCROOT}/../build/ios/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run" ]; then
+  # Swift Package Manager installation. Flutter passes -clonedSourcePackagesDirPath
+  # pointing to "<project>/build/ios/SourcePackages", which is always populated
+  # regardless of Xcode's IDEPackageOnlyUseVersionsFromResolvedFile setting.
+  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT="\${SRCROOT}/../build/ios/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
 else
   # Fall back to the Xcode DerivedData directory in case Swift Package Manager
   # checkouts are not resolved relative to "\$BUILD_DIR" (older/alternative setups).


### PR DESCRIPTION
## Description

Fixes #443

IDEPackageOnlyUseVersionsFromResolvedFile to YES to enforce Package.resolved deps resolution following happens:

- xcodebuild skips its own independent package resolution
- It only uses what's already provided (the -clonedSourcePackagesDirPath)
- It does not populate DerivedData/Runner-xxx/SourcePackages/

As a result build fails.

Changes in this PR will update the generated script to search for run script in `<project>/build/ios/SourcePackages`, which will be populated regardless of Xcode's IDEPackageOnlyUseVersionsFromResolvedFile setting.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
